### PR TITLE
fix!: align schema version with package.json major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The master spec includes a `meta` block that defines system-wide expectations:
 
 ## Structure of `config/standards.json`
 
-- `version` — schema version (currently `3`)
+- `version` — schema version (currently `2`)
 - `meta` — global rules and migration policy
 - `ciSystems` — supported CI platforms
   _(currently `github-actions`, `azure-devops`)_
@@ -101,8 +101,7 @@ Each checklist item includes:
 The `version` field indicates schema compatibility:
 
 - `1` — Original schema
-- `2` — Adds `bazelHints`, `meta.bazelIntegration` for Bazel support, `anyOfFiles`, `pinningNotes`
-- `3` — Enforces strict validation with `additionalProperties: false`. Adds enforcement/severity levels, ratio-based coverage thresholds, Rust/Go stacks, and refactors `bazelIntegration` → `executorHints.bazel`
+- `2` — Adds `bazelHints`, `meta.executorHints.bazel` for Bazel support, `anyOfFiles`, `pinningNotes`, enforcement/severity levels, ratio-based coverage thresholds, Rust/Go stacks. Enforces strict validation with `additionalProperties: false`.
 
 Consumers should ignore unknown fields for forward compatibility.
 

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["azure-devops"],

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["github-actions"],

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["azure-devops"],

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["github-actions"],

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.json
+++ b/config/standards.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "meta": {
     "defaultCoverageThreshold": 0.8,
     "coverageThresholdUnit": "ratio",

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["azure-devops"],

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["github-actions"],

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["azure-devops"],

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["github-actions"],

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.schema.json
+++ b/config/standards.schema.json
@@ -1,16 +1,16 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://oddessentials.com/schemas/repo-standards/v3/standards.schema.json",
+  "$id": "https://oddessentials.com/schemas/repo-standards/v2/standards.schema.json",
   "title": "Repository Standards Configuration",
-  "description": "Schema for repo-standards master configuration (v3+). Enforces strict validation with additionalProperties: false.",
+  "description": "Schema for repo-standards master configuration (v2+). Enforces strict validation with additionalProperties: false.",
   "type": "object",
   "required": ["version", "ciSystems", "stacks", "checklist"],
   "additionalProperties": false,
   "properties": {
     "version": {
       "type": "integer",
-      "minimum": 3,
-      "description": "Schema version. Must be 3+ for strict validation with additionalProperties: false."
+      "minimum": 2,
+      "description": "Schema version. Must be 2+ for strict validation with additionalProperties: false."
     },
     "meta": {
       "$ref": "#/$defs/Meta"

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["azure-devops"],

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["github-actions"],

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 2,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,9 +34,9 @@ describe("repo-standards API", () => {
 });
 
 describe("dependency governance items", () => {
-  it("schema version is 3", () => {
+  it("schema version is 2", () => {
     const spec = loadMasterSpec();
-    expect(spec.version).toBe(3);
+    expect(spec.version).toBe(2);
   });
 
   it("recommended section includes both dependency items", () => {
@@ -305,5 +305,17 @@ describe("documentation sync (prevents version drift)", () => {
     // Check that the version list includes the current version
     const versionListPattern = new RegExp(`-\\s*\`${actualVersion}\`\\s*—`);
     expect(readme).toMatch(versionListPattern);
+  });
+
+  it("schema version matches package.json major version", async () => {
+    const fs = await import("node:fs");
+    const path = await import("node:path");
+
+    const spec = loadMasterSpec();
+    const pkgPath = path.resolve(process.cwd(), "package.json");
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    const pkgMajor = parseInt(pkg.version.split(".")[0], 10);
+
+    expect(spec.version).toBe(pkgMajor);
   });
 });


### PR DESCRIPTION
BREAKING CHANGE: Schema version corrected from 3 to 2 to match package.json major.

- standards.json version: 3 -> 2

- standards.schema.json: , minimum, description updated to v2

- build.ts: syncSchemaVersion() auto-upgrades on major bump, fails if schema ahead

- index.test.ts: expects version 2, added version sync invariant test

- README.md: updated version references