### PR TITLE
Add release/versioning/provenance/determinism guidance and deterministic build checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,27 @@ Consumers should ignore unknown fields for forward compatibility.
 
 ---
 
+## Release, Versioning, Provenance, and Determinism
+
+The master spec now defines explicit **release/versioning/provenance/determinism** expectations. These map directly to checklist IDs in `config/standards.json`:
+
+- **Canonical version source & SemVer rules** → `semantic-versioning`
+  - Stack hints specify the canonical version source (e.g., package.json, git tags, Cargo.toml) and enforce SemVer.
+- **Automated changelog generation** → `semantic-versioning`
+  - Release tooling generates/updates `CHANGELOG.md` from commit history.
+- **Synchronized artifact publishing** → `semantic-versioning`
+  - Release workflows publish versioned artifacts in the same run that tags versions.
+- **Commit linting tied to release automation** → `commit-linting`
+  - Conventional Commits are required for automated versioning/changelog workflows.
+- **TypeScript-first expectations** → `type-checking` (TypeScript/JS stack hints)
+  - Prefer TypeScript for new/changed code; enforce strict type checks.
+- **Deterministic/hermetic build requirements** → `deterministic-builds` (plus `runtime-version`, `dependency-security`)
+  - Pin toolchains, lock dependencies, and run clean CI builds for reproducibility.
+- **Provenance/security scanning** → `provenance-security-scanning` (plus `dependency-security`)
+  - Generate SBOM/provenance and scan artifacts before publishing.
+
+---
+
 ## Dependency Governance (Recommended Items)
 
 Two recommended checklist items support supply-chain governance:

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -178,7 +178,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -187,7 +187,7 @@
         "stack": {
           "exampleTools": ["GitVersion"],
           "exampleConfigFiles": ["GitVersion.yml", "*.csproj", "CHANGELOG.md"],
-          "notes": "Use GitVersion to automatically compute SemVer from git history and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with release pipeline to automatically version assemblies, NuGet packages, and create release notes.",
+          "notes": "Treat GitVersion (git history/tags) as the canonical version source; avoid manual assembly version edits. Configure CI to generate/update CHANGELOG.md from commit messages and git tags, version assemblies/NuGet packages, and publish release artifacts as part of the release pipeline.",
           "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI automatically produces the expected version metadata, updates project files, and generates changelog entries from commit history."
         }
       },
@@ -203,8 +203,40 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.*", ".cz.toml"],
-          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it.",
+          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Create a test commit following the documented commit convention and confirm that any configured commit message checks (local hooks or CI) accept the message."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["global.json", "packages.lock.json"],
+          "notes": "Pin SDK versions, use lock files, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -178,7 +178,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -187,7 +187,7 @@
         "stack": {
           "exampleTools": ["GitVersion"],
           "exampleConfigFiles": ["GitVersion.yml", "*.csproj", "CHANGELOG.md"],
-          "notes": "Use GitVersion to automatically compute SemVer from git history and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with release pipeline to automatically version assemblies, NuGet packages, and create release notes.",
+          "notes": "Treat GitVersion (git history/tags) as the canonical version source; avoid manual assembly version edits. Configure CI to generate/update CHANGELOG.md from commit messages and git tags, version assemblies/NuGet packages, and publish release artifacts as part of the release pipeline.",
           "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI automatically produces the expected version metadata, updates project files, and generates changelog entries from commit history."
         }
       },
@@ -203,8 +203,40 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.*", ".cz.toml"],
-          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it.",
+          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Create a test commit following the documented commit convention and confirm that any configured commit message checks (local hooks or CI) accept the message."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["global.json", "packages.lock.json"],
+          "notes": "Pin SDK versions, use lock files, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -190,7 +190,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -202,7 +202,7 @@
         "stack": {
           "exampleTools": ["GitVersion"],
           "exampleConfigFiles": ["GitVersion.yml", "*.csproj", "CHANGELOG.md"],
-          "notes": "Use GitVersion to automatically compute SemVer from git history and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with release pipeline to automatically version assemblies, NuGet packages, and create release notes.",
+          "notes": "Treat GitVersion (git history/tags) as the canonical version source; avoid manual assembly version edits. Configure CI to generate/update CHANGELOG.md from commit messages and git tags, version assemblies/NuGet packages, and publish release artifacts as part of the release pipeline.",
           "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI automatically produces the expected version metadata, updates project files, and generates changelog entries from commit history."
         }
       },
@@ -221,8 +221,46 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.*", ".cz.toml"],
-          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it.",
+          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Create a test commit following the documented commit convention and confirm that any configured commit message checks (local hooks or CI) accept the message."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["global.json", "packages.lock.json"],
+          "notes": "Pin SDK versions, use lock files, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -188,7 +188,7 @@
         "stack": {
           "exampleTools": ["goreleaser", "semantic-release"],
           "exampleConfigFiles": [".goreleaser.yml", "CHANGELOG.md"],
-          "notes": "Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.",
+          "notes": "Git tags (vMAJOR.MINOR.PATCH) are the canonical version source. Use goreleaser or semantic-release to generate changelogs, tag releases, and publish artifacts in a synchronized workflow.",
           "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs."
         }
       },
@@ -204,8 +204,40 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.",
+          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Release automation and goreleaser changelogs depend on Conventional Commit history.",
           "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["go.sum", ".go-version"],
+          "notes": "Pin Go/tooling versions, rely on go.sum, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -188,7 +188,7 @@
         "stack": {
           "exampleTools": ["goreleaser", "semantic-release"],
           "exampleConfigFiles": [".goreleaser.yml", "CHANGELOG.md"],
-          "notes": "Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.",
+          "notes": "Git tags (vMAJOR.MINOR.PATCH) are the canonical version source. Use goreleaser or semantic-release to generate changelogs, tag releases, and publish artifacts in a synchronized workflow.",
           "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs."
         }
       },
@@ -204,8 +204,40 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.",
+          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Release automation and goreleaser changelogs depend on Conventional Commit history.",
           "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["go.sum", ".go-version"],
+          "notes": "Pin Go/tooling versions, rely on go.sum, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -191,7 +191,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -203,7 +203,7 @@
         "stack": {
           "exampleTools": ["goreleaser", "semantic-release"],
           "exampleConfigFiles": [".goreleaser.yml", "CHANGELOG.md"],
-          "notes": "Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.",
+          "notes": "Git tags (vMAJOR.MINOR.PATCH) are the canonical version source. Use goreleaser or semantic-release to generate changelogs, tag releases, and publish artifacts in a synchronized workflow.",
           "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs."
         }
       },
@@ -222,8 +222,46 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.",
+          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Release automation and goreleaser changelogs depend on Conventional Commit history.",
           "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["go.sum", ".go-version"],
+          "notes": "Pin Go/tooling versions, rely on go.sum, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.json
+++ b/config/standards.json
@@ -429,7 +429,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "appliesTo": {
           "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
         },
@@ -449,7 +449,7 @@
               "package.json",
               "CHANGELOG.md"
             ],
-            "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to automatically bump package.json version, generate/update CHANGELOG.md, create git tags, and publish release artifacts. Protect release branches and ensure release tooling only runs there.",
+            "notes": "Treat package.json as the canonical version source. Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to bump package.json, update CHANGELOG.md, create git tags, and publish release artifacts in the same workflow.",
             "verification": "Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries."
           },
           "csharp-dotnet": {
@@ -459,7 +459,7 @@
               "*.csproj",
               "CHANGELOG.md"
             ],
-            "notes": "Use GitVersion to automatically compute SemVer from git history and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with release pipeline to automatically version assemblies, NuGet packages, and create release notes.",
+            "notes": "Treat GitVersion (git history/tags) as the canonical version source; avoid manual assembly version edits. Configure CI to generate/update CHANGELOG.md from commit messages and git tags, version assemblies/NuGet packages, and publish release artifacts as part of the release pipeline.",
             "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI automatically produces the expected version metadata, updates project files, and generates changelog entries from commit history."
           },
           "python": {
@@ -469,19 +469,19 @@
               "setup.cfg",
               "CHANGELOG.md"
             ],
-            "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Configure CI to automatically update version in pyproject.toml, generate/update CHANGELOG.md from commit messages or changelog fragments, and create git tags. Maintain a single source of truth for versioning.",
+            "notes": "Treat pyproject.toml/setuptools_scm as the canonical version source (git tags or bumpversion). Configure CI to update versions, generate/update CHANGELOG.md, create git tags, and publish release artifacts in one workflow. Maintain a single source of truth for versioning.",
             "verification": "Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments."
           },
           "rust": {
             "exampleTools": ["cargo-release", "semantic-release"],
             "exampleConfigFiles": ["Cargo.toml", "CHANGELOG.md"],
-            "notes": "Version is defined in Cargo.toml. Use cargo-release or semantic-release-cargo for automated versioning. Follow Conventional Commits for changelog generation.",
+            "notes": "Cargo.toml is the canonical version source. Use cargo-release or semantic-release-cargo to bump versions, generate changelog entries from Conventional Commits, tag releases, and publish artifacts together.",
             "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history."
           },
           "go": {
             "exampleTools": ["goreleaser", "semantic-release"],
             "exampleConfigFiles": [".goreleaser.yml", "CHANGELOG.md"],
-            "notes": "Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.",
+            "notes": "Git tags (vMAJOR.MINOR.PATCH) are the canonical version source. Use goreleaser or semantic-release to generate changelogs, tag releases, and publish artifacts in a synchronized workflow.",
             "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs."
           }
         },
@@ -510,32 +510,155 @@
               "@commitlint/config-conventional"
             ],
             "exampleConfigFiles": ["commitlint.config.*"],
-            "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.",
+            "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI. Release automation depends on Conventional Commits for versioning and changelog generation.",
             "verification": "Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen)."
           },
           "csharp-dotnet": {
             "exampleTools": ["commitlint", "commitizen"],
             "exampleConfigFiles": ["commitlint.config.*", ".cz.toml"],
-            "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it.",
+            "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it. Release automation depends on Conventional Commits for versioning and changelog generation.",
             "verification": "Create a test commit following the documented commit convention and confirm that any configured commit message checks (local hooks or CI) accept the message."
           },
           "python": {
             "exampleTools": ["commitizen"],
             "exampleConfigFiles": [".cz.toml", "pyproject.toml"],
-            "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes.",
+            "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes. Release automation depends on commit messages for versioning and changelog generation.",
             "verification": "Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted."
           },
           "rust": {
             "exampleTools": ["commitlint", "commitizen"],
             "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-            "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.",
+            "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Release automation depends on Conventional Commits for versioning and changelog generation.",
             "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
           },
           "go": {
             "exampleTools": ["commitlint", "commitizen"],
             "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-            "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.",
+            "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Release automation and goreleaser changelogs depend on Conventional Commit history.",
             "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+          }
+        },
+        "enforcement": "required",
+        "severity": "error"
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stackHints": {
+          "typescript-js": {
+            "exampleTools": [],
+            "exampleConfigFiles": [
+              "package-lock.json",
+              "pnpm-lock.yaml",
+              "yarn.lock"
+            ],
+            "notes": "Pin Node/tooling versions, use a lockfile, and run builds in clean CI containers so outputs are reproducible and hermetic.",
+            "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+          },
+          "csharp-dotnet": {
+            "exampleTools": [],
+            "exampleConfigFiles": ["global.json", "packages.lock.json"],
+            "notes": "Pin SDK versions, use lock files, and build in clean CI environments so outputs are reproducible and hermetic.",
+            "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+          },
+          "python": {
+            "exampleTools": [],
+            "exampleConfigFiles": [
+              "requirements.txt",
+              "poetry.lock",
+              "Pipfile.lock"
+            ],
+            "notes": "Pin Python/tooling versions, use lockfiles, and build in clean CI environments so outputs are reproducible and hermetic.",
+            "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+          },
+          "rust": {
+            "exampleTools": [],
+            "exampleConfigFiles": ["Cargo.lock", "rust-toolchain.toml"],
+            "notes": "Pin Rust/tooling versions, use Cargo.lock, and build in clean CI environments so outputs are reproducible and hermetic.",
+            "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+          },
+          "go": {
+            "exampleTools": [],
+            "exampleConfigFiles": ["go.sum", ".go-version"],
+            "notes": "Pin Go/tooling versions, rely on go.sum, and build in clean CI environments so outputs are reproducible and hermetic.",
+            "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+          }
+        },
+        "enforcement": "required",
+        "severity": "error"
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stackHints": {
+          "typescript-js": {
+            "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+            "exampleConfigFiles": [
+              ".github/workflows/*",
+              "azure-pipelines.yml"
+            ],
+            "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+            "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
+          },
+          "csharp-dotnet": {
+            "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+            "exampleConfigFiles": [
+              ".github/workflows/*",
+              "azure-pipelines.yml"
+            ],
+            "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+            "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
+          },
+          "python": {
+            "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+            "exampleConfigFiles": [
+              ".github/workflows/*",
+              "azure-pipelines.yml"
+            ],
+            "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+            "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
+          },
+          "rust": {
+            "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+            "exampleConfigFiles": [
+              ".github/workflows/*",
+              "azure-pipelines.yml"
+            ],
+            "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+            "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
+          },
+          "go": {
+            "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+            "exampleConfigFiles": [
+              ".github/workflows/*",
+              "azure-pipelines.yml"
+            ],
+            "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+            "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
           }
         },
         "enforcement": "required",
@@ -842,7 +965,7 @@
           "typescript-js": {
             "exampleTools": ["TypeScript compiler (tsc)"],
             "exampleConfigFiles": ["tsconfig.json"],
-            "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.",
+            "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules. Prefer TypeScript-first development over new plain JavaScript.",
             "verification": "Presence of tsconfig.json indicates type-checking is configured for the repository.",
             "requiredFiles": ["tsconfig.json"],
             "requiredScripts": ["typecheck"],

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -184,7 +184,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -193,7 +193,7 @@
         "stack": {
           "exampleTools": ["bumpversion", "setuptools_scm", "towncrier"],
           "exampleConfigFiles": ["pyproject.toml", "setup.cfg", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Configure CI to automatically update version in pyproject.toml, generate/update CHANGELOG.md from commit messages or changelog fragments, and create git tags. Maintain a single source of truth for versioning.",
+          "notes": "Treat pyproject.toml/setuptools_scm as the canonical version source (git tags or bumpversion). Configure CI to update versions, generate/update CHANGELOG.md, create git tags, and publish release artifacts in one workflow. Maintain a single source of truth for versioning.",
           "verification": "Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments."
         }
       },
@@ -209,8 +209,44 @@
         "stack": {
           "exampleTools": ["commitizen"],
           "exampleConfigFiles": [".cz.toml", "pyproject.toml"],
-          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes.",
+          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes. Release automation depends on commit messages for versioning and changelog generation.",
           "verification": "Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": [
+            "requirements.txt",
+            "poetry.lock",
+            "Pipfile.lock"
+          ],
+          "notes": "Pin Python/tooling versions, use lockfiles, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -184,7 +184,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -193,7 +193,7 @@
         "stack": {
           "exampleTools": ["bumpversion", "setuptools_scm", "towncrier"],
           "exampleConfigFiles": ["pyproject.toml", "setup.cfg", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Configure CI to automatically update version in pyproject.toml, generate/update CHANGELOG.md from commit messages or changelog fragments, and create git tags. Maintain a single source of truth for versioning.",
+          "notes": "Treat pyproject.toml/setuptools_scm as the canonical version source (git tags or bumpversion). Configure CI to update versions, generate/update CHANGELOG.md, create git tags, and publish release artifacts in one workflow. Maintain a single source of truth for versioning.",
           "verification": "Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments."
         }
       },
@@ -209,8 +209,44 @@
         "stack": {
           "exampleTools": ["commitizen"],
           "exampleConfigFiles": [".cz.toml", "pyproject.toml"],
-          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes.",
+          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes. Release automation depends on commit messages for versioning and changelog generation.",
           "verification": "Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": [
+            "requirements.txt",
+            "poetry.lock",
+            "Pipfile.lock"
+          ],
+          "notes": "Pin Python/tooling versions, use lockfiles, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -196,7 +196,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -208,7 +208,7 @@
         "stack": {
           "exampleTools": ["bumpversion", "setuptools_scm", "towncrier"],
           "exampleConfigFiles": ["pyproject.toml", "setup.cfg", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Configure CI to automatically update version in pyproject.toml, generate/update CHANGELOG.md from commit messages or changelog fragments, and create git tags. Maintain a single source of truth for versioning.",
+          "notes": "Treat pyproject.toml/setuptools_scm as the canonical version source (git tags or bumpversion). Configure CI to update versions, generate/update CHANGELOG.md, create git tags, and publish release artifacts in one workflow. Maintain a single source of truth for versioning.",
           "verification": "Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments."
         }
       },
@@ -227,8 +227,50 @@
         "stack": {
           "exampleTools": ["commitizen"],
           "exampleConfigFiles": [".cz.toml", "pyproject.toml"],
-          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes.",
+          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes. Release automation depends on commit messages for versioning and changelog generation.",
           "verification": "Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": [
+            "requirements.txt",
+            "poetry.lock",
+            "Pipfile.lock"
+          ],
+          "notes": "Pin Python/tooling versions, use lockfiles, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -188,7 +188,7 @@
         "stack": {
           "exampleTools": ["cargo-release", "semantic-release"],
           "exampleConfigFiles": ["Cargo.toml", "CHANGELOG.md"],
-          "notes": "Version is defined in Cargo.toml. Use cargo-release or semantic-release-cargo for automated versioning. Follow Conventional Commits for changelog generation.",
+          "notes": "Cargo.toml is the canonical version source. Use cargo-release or semantic-release-cargo to bump versions, generate changelog entries from Conventional Commits, tag releases, and publish artifacts together.",
           "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history."
         }
       },
@@ -204,8 +204,40 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.",
+          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["Cargo.lock", "rust-toolchain.toml"],
+          "notes": "Pin Rust/tooling versions, use Cargo.lock, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -188,7 +188,7 @@
         "stack": {
           "exampleTools": ["cargo-release", "semantic-release"],
           "exampleConfigFiles": ["Cargo.toml", "CHANGELOG.md"],
-          "notes": "Version is defined in Cargo.toml. Use cargo-release or semantic-release-cargo for automated versioning. Follow Conventional Commits for changelog generation.",
+          "notes": "Cargo.toml is the canonical version source. Use cargo-release or semantic-release-cargo to bump versions, generate changelog entries from Conventional Commits, tag releases, and publish artifacts together.",
           "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history."
         }
       },
@@ -204,8 +204,40 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.",
+          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["Cargo.lock", "rust-toolchain.toml"],
+          "notes": "Pin Rust/tooling versions, use Cargo.lock, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -191,7 +191,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -203,7 +203,7 @@
         "stack": {
           "exampleTools": ["cargo-release", "semantic-release"],
           "exampleConfigFiles": ["Cargo.toml", "CHANGELOG.md"],
-          "notes": "Version is defined in Cargo.toml. Use cargo-release or semantic-release-cargo for automated versioning. Follow Conventional Commits for changelog generation.",
+          "notes": "Cargo.toml is the canonical version source. Use cargo-release or semantic-release-cargo to bump versions, generate changelog entries from Conventional Commits, tag releases, and publish artifacts together.",
           "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history."
         }
       },
@@ -222,8 +222,46 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.",
+          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": ["Cargo.lock", "rust-toolchain.toml"],
+          "notes": "Pin Rust/tooling versions, use Cargo.lock, and build in clean CI environments so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -201,7 +201,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -210,7 +210,7 @@
         "stack": {
           "exampleTools": ["semantic-release", "standard-version"],
           "exampleConfigFiles": [".releaserc", "package.json", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to automatically bump package.json version, generate/update CHANGELOG.md, create git tags, and publish release artifacts. Protect release branches and ensure release tooling only runs there.",
+          "notes": "Treat package.json as the canonical version source. Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to bump package.json, update CHANGELOG.md, create git tags, and publish release artifacts in the same workflow.",
           "verification": "Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries."
         }
       },
@@ -229,8 +229,44 @@
             "@commitlint/config-conventional"
           ],
           "exampleConfigFiles": ["commitlint.config.*"],
-          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.",
+          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen)."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": [
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock"
+          ],
+          "notes": "Pin Node/tooling versions, use a lockfile, and run builds in clean CI containers so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {
@@ -324,7 +360,7 @@
         "stack": {
           "exampleTools": ["TypeScript compiler (tsc)"],
           "exampleConfigFiles": ["tsconfig.json"],
-          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.",
+          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules. Prefer TypeScript-first development over new plain JavaScript.",
           "verification": "Presence of tsconfig.json indicates type-checking is configured for the repository.",
           "requiredFiles": ["tsconfig.json"],
           "requiredScripts": ["typecheck"],

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -201,7 +201,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -210,7 +210,7 @@
         "stack": {
           "exampleTools": ["semantic-release", "standard-version"],
           "exampleConfigFiles": [".releaserc", "package.json", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to automatically bump package.json version, generate/update CHANGELOG.md, create git tags, and publish release artifacts. Protect release branches and ensure release tooling only runs there.",
+          "notes": "Treat package.json as the canonical version source. Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to bump package.json, update CHANGELOG.md, create git tags, and publish release artifacts in the same workflow.",
           "verification": "Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries."
         }
       },
@@ -229,8 +229,44 @@
             "@commitlint/config-conventional"
           ],
           "exampleConfigFiles": ["commitlint.config.*"],
-          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.",
+          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen)."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": [
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock"
+          ],
+          "notes": "Pin Node/tooling versions, use a lockfile, and run builds in clean CI containers so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {
@@ -324,7 +360,7 @@
         "stack": {
           "exampleTools": ["TypeScript compiler (tsc)"],
           "exampleConfigFiles": ["tsconfig.json"],
-          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.",
+          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules. Prefer TypeScript-first development over new plain JavaScript.",
           "verification": "Presence of tsconfig.json indicates type-checking is configured for the repository.",
           "requiredFiles": ["tsconfig.json"],
           "requiredScripts": ["typecheck"],

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -213,7 +213,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -225,7 +225,7 @@
         "stack": {
           "exampleTools": ["semantic-release", "standard-version"],
           "exampleConfigFiles": [".releaserc", "package.json", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to automatically bump package.json version, generate/update CHANGELOG.md, create git tags, and publish release artifacts. Protect release branches and ensure release tooling only runs there.",
+          "notes": "Treat package.json as the canonical version source. Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to bump package.json, update CHANGELOG.md, create git tags, and publish release artifacts in the same workflow.",
           "verification": "Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries."
         }
       },
@@ -247,8 +247,50 @@
             "@commitlint/config-conventional"
           ],
           "exampleConfigFiles": ["commitlint.config.*"],
-          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.",
+          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI. Release automation depends on Conventional Commits for versioning and changelog generation.",
           "verification": "Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen)."
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic/Hermetic Builds",
+        "description": "Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [],
+          "exampleConfigFiles": [
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock"
+          ],
+          "notes": "Pin Node/tooling versions, use a lockfile, and run builds in clean CI containers so outputs are reproducible and hermetic.",
+          "verification": "Re-run the build in CI and confirm outputs are consistent across runs."
+        }
+      },
+      {
+        "id": "provenance-security-scanning",
+        "label": "Provenance & Security Scanning",
+        "description": "Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["slsa-provenance", "cosign", "syft", "grype"],
+          "exampleConfigFiles": [".github/workflows/*", "azure-pipelines.yml"],
+          "notes": "Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.",
+          "verification": "Release workflows emit provenance/SBOM artifacts and security scans complete without untriaged critical findings."
         }
       },
       {
@@ -357,7 +399,7 @@
         "stack": {
           "exampleTools": ["TypeScript compiler (tsc)"],
           "exampleConfigFiles": ["tsconfig.json"],
-          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.",
+          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules. Prefer TypeScript-first development over new plain JavaScript.",
           "verification": "Presence of tsconfig.json indicates type-checking is configured for the repository.",
           "requiredFiles": ["tsconfig.json"],
           "requiredScripts": ["typecheck"],

--- a/instructions.csharp-dotnet.github-actions.md
+++ b/instructions.csharp-dotnet.github-actions.md
@@ -1,6 +1,6 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config\standards.csharp-dotnet.github-actions.json`
+> Auto-generated from `config/standards.csharp-dotnet.github-actions.json`
 > Stack: C# / .NET | CI: github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
@@ -19,7 +19,6 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Ensure .editorconfig exists in the repository.
 - Consider adding Directory.Build.props if applicable.
-- Define a `lint` script or equivalent command.
 - Enable analyzers or style rules for the solution and review warnings regularly; enforce stricter rules on new code.
 
 ### Unit Test Runner
@@ -37,12 +36,23 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.
+- Treat GitVersion (git history/tags) as the canonical version source; avoid manual assembly version edits. Configure CI to generate/update CHANGELOG.md from commit messages and git tags, version assemblies/NuGet packages, and publish release artifacts as part of the release pipeline.
 
 ### Commit Linting
 
 - Enforce structured commit messages such as Conventional Commits.
-- Document your commit convention and wire up a helper tool so contributors can easily follow it.
+- Document your commit convention and wire up a helper tool so contributors can easily follow it. Release automation depends on Conventional Commits for versioning and changelog generation.
+
+### Deterministic/Hermetic Builds
+
+- Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.
+- Pin SDK versions, use lock files, and build in clean CI environments so outputs are reproducible and hermetic.
+
+### Provenance & Security Scanning
+
+- Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.
+- Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.
 
 ### Unit Test Reporter / Coverage
 
@@ -69,7 +79,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Ensure .editorconfig exists in the repository.
 - Consider adding Directory.Build.props if applicable.
-- Define a `typecheck` script or equivalent command.
+- Enable nullable reference types and relevant analyzers to catch type and nullability issues at compile time. C# project files (\*.csproj) indicate the presence of projects that can be type-checked.
 
 ### Dependency Management & Vulnerability Scanning
 
@@ -81,6 +91,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
 - Consider adding global.json if applicable.
+- Specify TargetFramework in .csproj files (e.g., <TargetFramework>net8.0</TargetFramework>) and optionally use global.json to pin the SDK version (e.g., { "sdk": { "version": "8.0.100" } }) for consistent builds across the team.
 
 ### Documentation Standards
 
@@ -97,6 +108,17 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Document contribution expectations and ensure legal and code-of-conduct policies are easy to find.
 
 ## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Both support NuGet packages. Renovate has better Central Package Management (Directory.Packages.props) support. For AzDO: use self-hosted Renovate runner.
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Consider adding NsDepCop.config.nsdepcop if applicable.
+- NsDepCop enforces namespace dependency rules via config file. ArchUnitNET uses test code for architectural assertions.
 
 ### Integration Testing
 

--- a/instructions.md
+++ b/instructions.md
@@ -12,20 +12,20 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
 - Consider adding .dockerignore if applicable.
+- Use the official github/gitignore Node template as a base and add .env*, node_modules, dist/, coverage/, *.log, npm-debug.log\*, etc. .dockerignore must exclude node_modules, .git, and local build output.
 
 ### Linting
 
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure eslint.config.js exists in the repository.
-- Consider adding .eslintrc.js, .eslintrc.cjs, .eslintrc.json and others if applicable.
-- Define a `lint` script in package.json or equivalent.
+- Consider adding .prettierrc, prettier.config.js, prettier.config.cjs and others if applicable.
+- Define a `lint` script or equivalent command.
 - Treat new lint errors as CI failures; keep existing issues as warnings until addressed.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
-- Define a `test` script in package.json or equivalent.
+- Define a `test` script or equivalent command.
 - Keep unit tests fast and deterministic; move slow or flaky tests into integration or E2E suites.
 
 ### Containerization (Docker / Docker Compose)
@@ -37,12 +37,23 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.
+- Treat package.json as the canonical version source. Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to bump package.json, update CHANGELOG.md, create git tags, and publish release artifacts in the same workflow.
 
 ### Commit Linting
 
 - Enforce structured commit messages such as Conventional Commits.
-- Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.
+- Enforce commit message format via commit-msg hooks (e.g., Husky) before CI. Release automation depends on Conventional Commits for versioning and changelog generation.
+
+### Deterministic/Hermetic Builds
+
+- Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.
+- Pin Node/tooling versions, use a lockfile, and run builds in clean CI containers so outputs are reproducible and hermetic.
+
+### Provenance & Security Scanning
+
+- Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.
+- Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.
 
 ### Unit Test Reporter / Coverage
 
@@ -68,14 +79,20 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Ensure tsconfig.json exists in the repository.
-- Define a `typecheck` script in package.json or equivalent.
-- Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.
+- Define a `typecheck` script or equivalent command.
+- Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules. Prefer TypeScript-first development over new plain JavaScript.
 
 ### Dependency Management & Vulnerability Scanning
 
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
 - Consider adding package-lock.json, pnpm-lock.yaml, yarn.lock if applicable.
 - Require a lockfile for reproducible installs and pin Node.js/tooling versions; block merges on new high-severity vulnerabilities.
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Ensure package.json exists in the repository.
+- Specify the 'engines' field in package.json to define the required Node.js version (e.g., "engines": { "node": ">=18.0.0" }). This helps prevent environment-related bugs and ensures all developers use compatible Node.js versions.
 
 ### Documentation Standards
 
@@ -92,6 +109,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use an SPDX license identifier in package.json and describe review expectations, tests, and docs requirements in CONTRIBUTING.md.
 
 ## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Renovate supports GHA + AzDO (self-hosted or Mend Renovate App). Dependabot is GitHub-native only. For AzDO: use Renovate via self-hosted runner, Docker container job, or Mend's hosted service.
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Define forbidden imports, layer rules, and circular dependency bans. Run in CI as blocking check.
 
 ### Integration Testing
 

--- a/instructions.python.github-actions.md
+++ b/instructions.python.github-actions.md
@@ -1,6 +1,6 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config\standards.python.github-actions.json`
+> Auto-generated from `config/standards.python.github-actions.json`
 > Stack: Python | CI: github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
@@ -12,20 +12,17 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
 - Consider adding .dockerignore if applicable.
+- Use the official github/gitignore Python template. Include **pycache**, .venv/, .pytest_cache, .env, and similar local-only files. .dockerignore must exclude .git, virtual environments, and caches.
 
 ### Linting
 
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure pyproject.toml exists in the repository.
-- Consider adding ruff.toml, .flake8 if applicable.
-- Define a `lint` script or equivalent command.
 - Configure a primary linter (such as ruff) and keep rules focused on catching real issues without overwhelming developers.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
-- Define a `test` script or equivalent command.
 - Organize unit tests under a tests/ directory and avoid real network or database calls in this layer.
 
 ### Containerization (Docker / Docker Compose)
@@ -37,12 +34,23 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.
+- Treat pyproject.toml/setuptools_scm as the canonical version source (git tags or bumpversion). Configure CI to update versions, generate/update CHANGELOG.md, create git tags, and publish release artifacts in one workflow. Maintain a single source of truth for versioning.
 
 ### Commit Linting
 
 - Enforce structured commit messages such as Conventional Commits.
-- Standardize commit messages using commitizen or a similar helper and document the required types and scopes.
+- Standardize commit messages using commitizen or a similar helper and document the required types and scopes. Release automation depends on commit messages for versioning and changelog generation.
+
+### Deterministic/Hermetic Builds
+
+- Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.
+- Pin Python/tooling versions, use lockfiles, and build in clean CI environments so outputs are reproducible and hermetic.
+
+### Provenance & Security Scanning
+
+- Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.
+- Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.
 
 ### Unit Test Reporter / Coverage
 
@@ -69,7 +77,6 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Ensure pyproject.toml exists in the repository.
 - Consider adding mypy.ini if applicable.
-- Define a `typecheck` script or equivalent command.
 - Adopt gradual typing with type hints and mypy, focusing first on critical modules and new code paths.
 
 ### Dependency Management & Vulnerability Scanning
@@ -83,6 +90,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
 - Ensure pyproject.toml exists in the repository.
 - Consider adding .python-version if applicable.
+- Specify python_requires in pyproject.toml (e.g., requires-python = ">=3.9") or setup.py (e.g., python_requires='>=3.9'). Consider adding .python-version for pyenv users to automatically switch to the correct Python version.
 
 ### Documentation Standards
 
@@ -99,6 +107,17 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Spell out contributor responsibilities for tests, documentation, and review so expectations are clear for Python-focused teams.
 
 ## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Renovate supports pyproject.toml, requirements.txt, Pipfile, poetry.lock. For AzDO: self-hosted Renovate or schedule-triggered pipeline.
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Consider adding pyproject.toml, .importlinter if applicable.
+- Configure [tool.importlinter] in pyproject.toml OR use standalone .importlinter file. pydeps is visualization-only.
 
 ### Integration Testing
 

--- a/instructions.python.md
+++ b/instructions.python.md
@@ -1,6 +1,6 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config\standards.python.json`
+> Auto-generated from `config/standards.python.json`
 > Stack: Python | CI: azure-devops, github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
@@ -12,20 +12,17 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
 - Consider adding .dockerignore if applicable.
+- Use the official github/gitignore Python template. Include **pycache**, .venv/, .pytest_cache, .env, and similar local-only files. .dockerignore must exclude .git, virtual environments, and caches.
 
 ### Linting
 
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure pyproject.toml exists in the repository.
-- Consider adding ruff.toml, .flake8 if applicable.
-- Define a `lint` script in package.json or equivalent.
 - Configure a primary linter (such as ruff) and keep rules focused on catching real issues without overwhelming developers.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
-- Define a `test` script in package.json or equivalent.
 - Organize unit tests under a tests/ directory and avoid real network or database calls in this layer.
 
 ### Containerization (Docker / Docker Compose)
@@ -37,13 +34,23 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
-- Use a single source of truth for the package version and keep it aligned with SemVer and your release notes.
+- Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.
+- Treat pyproject.toml/setuptools_scm as the canonical version source (git tags or bumpversion). Configure CI to update versions, generate/update CHANGELOG.md, create git tags, and publish release artifacts in one workflow. Maintain a single source of truth for versioning.
 
 ### Commit Linting
 
 - Enforce structured commit messages such as Conventional Commits.
-- Standardize commit messages using commitizen or a similar helper and document the required types and scopes.
+- Standardize commit messages using commitizen or a similar helper and document the required types and scopes. Release automation depends on commit messages for versioning and changelog generation.
+
+### Deterministic/Hermetic Builds
+
+- Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.
+- Pin Python/tooling versions, use lockfiles, and build in clean CI environments so outputs are reproducible and hermetic.
+
+### Provenance & Security Scanning
+
+- Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.
+- Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.
 
 ### Unit Test Reporter / Coverage
 
@@ -70,7 +77,6 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Ensure pyproject.toml exists in the repository.
 - Consider adding mypy.ini if applicable.
-- Define a `typecheck` script in package.json or equivalent.
 - Adopt gradual typing with type hints and mypy, focusing first on critical modules and new code paths.
 
 ### Dependency Management & Vulnerability Scanning
@@ -78,6 +84,13 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
 - Consider adding requirements.txt, Pipfile.lock, poetry.lock if applicable.
 - Pin dependency versions and routinely scan for vulnerabilities, prioritizing fixes for critical and high-severity issues.
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Ensure pyproject.toml exists in the repository.
+- Consider adding .python-version if applicable.
+- Specify python_requires in pyproject.toml (e.g., requires-python = ">=3.9") or setup.py (e.g., python_requires='>=3.9'). Consider adding .python-version for pyenv users to automatically switch to the correct Python version.
 
 ### Documentation Standards
 
@@ -94,6 +107,17 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Spell out contributor responsibilities for tests, documentation, and review so expectations are clear for Python-focused teams.
 
 ## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Renovate supports pyproject.toml, requirements.txt, Pipfile, poetry.lock. For AzDO: self-hosted Renovate or schedule-triggered pipeline.
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Consider adding pyproject.toml, .importlinter if applicable.
+- Configure [tool.importlinter] in pyproject.toml OR use standalone .importlinter file. pydeps is visualization-only.
 
 ### Integration Testing
 

--- a/instructions.typescript-js.github-actions.md
+++ b/instructions.typescript-js.github-actions.md
@@ -1,6 +1,6 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config\standards.typescript-js.github-actions.json`
+> Auto-generated from `config/standards.typescript-js.github-actions.json`
 > Stack: TypeScript / JavaScript | CI: github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
@@ -12,12 +12,12 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
 - Consider adding .dockerignore if applicable.
+- Use the official github/gitignore Node template as a base and add .env*, node_modules, dist/, coverage/, *.log, npm-debug.log\*, etc. .dockerignore must exclude node_modules, .git, and local build output.
 
 ### Linting
 
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure eslint.config.js exists in the repository.
-- Consider adding .eslintrc.js, .eslintrc.cjs, .eslintrc.json and others if applicable.
+- Consider adding .prettierrc, prettier.config.js, prettier.config.cjs and others if applicable.
 - Define a `lint` script or equivalent command.
 - Treat new lint errors as CI failures; keep existing issues as warnings until addressed.
 
@@ -37,12 +37,23 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Use MAJOR.MINOR.PATCH versioning with a single canonical version source, automated changelog generation, and synchronized artifact publishing.
+- Treat package.json as the canonical version source. Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to bump package.json, update CHANGELOG.md, create git tags, and publish release artifacts in the same workflow.
 
 ### Commit Linting
 
 - Enforce structured commit messages such as Conventional Commits.
-- Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.
+- Enforce commit message format via commit-msg hooks (e.g., Husky) before CI. Release automation depends on Conventional Commits for versioning and changelog generation.
+
+### Deterministic/Hermetic Builds
+
+- Ensure builds are reproducible and hermetic by pinning toolchains, locking dependencies, and avoiding hidden network inputs.
+- Pin Node/tooling versions, use a lockfile, and run builds in clean CI containers so outputs are reproducible and hermetic.
+
+### Provenance & Security Scanning
+
+- Generate provenance/attestations for release artifacts and scan dependencies/artifacts for security issues before publishing.
+- Publish SBOMs and provenance attestations with release artifacts and scan dependencies/images before publishing.
 
 ### Unit Test Reporter / Coverage
 
@@ -69,7 +80,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Ensure tsconfig.json exists in the repository.
 - Define a `typecheck` script or equivalent command.
-- Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.
+- Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules. Prefer TypeScript-first development over new plain JavaScript.
 
 ### Dependency Management & Vulnerability Scanning
 
@@ -81,6 +92,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
 - Ensure package.json exists in the repository.
+- Specify the 'engines' field in package.json to define the required Node.js version (e.g., "engines": { "node": ">=18.0.0" }). This helps prevent environment-related bugs and ensures all developers use compatible Node.js versions.
 
 ### Documentation Standards
 
@@ -97,6 +109,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use an SPDX license identifier in package.json and describe review expectations, tests, and docs requirements in CONTRIBUTING.md.
 
 ## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Renovate supports GHA + AzDO (self-hosted or Mend Renovate App). Dependabot is GitHub-native only. For AzDO: use Renovate via self-hosted runner, Docker container job, or Mend's hosted service.
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Define forbidden imports, layer rules, and circular dependency bans. Run in CI as blocking check.
 
 ### Integration Testing
 

--- a/scripts/generate-instructions.ts
+++ b/scripts/generate-instructions.ts
@@ -67,8 +67,8 @@ function generateBullets(item: ChecklistItem): string[] {
     bullets.push(`Define a ${scripts} script or equivalent command.`);
   }
 
-  // Bullet 5: Notes-based guidance (if short enough)
-  if (stack?.notes && stack.notes.length < 150) {
+  // Bullet 5: Notes-based guidance
+  if (stack?.notes) {
     bullets.push(stack.notes);
   }
 


### PR DESCRIPTION
### Motivation

- Clarify repository expectations for release/versioning, changelogs, artifact publishing, provenance, and deterministic builds and map them to the master spec.
- Ensure commit linting, changelog automation, and version sources are explicitly documented and tied to release automation.
- Encourage TypeScript-first development for JS stacks and require hermetic/deterministic build practices.
- Make generated human-facing instructions include full, user-visible notes from the machine-readable spec.

### Description

- Add a new README section `Release, Versioning, Provenance, and Determinism` mapping the behaviors to checklist IDs in `config/standards.json`.
- Update `config/standards.json` (and regenerated per-stack views) to expand `semantic-versioning` notes, annotate `commit-linting` and `type-checking` (TypeScript-first), and add two new checklist items: `deterministic-builds` and `provenance-security-scanning`.
- Change `scripts/generate-instructions.ts` to always include `stack.notes` when generating instruction bullets, and regenerate stack-specific JSON files and `instructions*.md` artifacts.
- Update the generated instruction documents (`instructions.md`, `instructions.*.md`) and multiple `config/standards.*.json` outputs to reflect the new guidance.

### Testing

- Ran `npm run generate:standards` to regenerate stack-specific JSON files, which wrote the updated `config/standards.*.json` outputs successfully.
- Ran `npx tsx scripts/generate-instructions.ts` (via `npx`) to regenerate `instructions*.md` files, which wrote the updated instruction documents successfully.
- Commits invoked pre-commit hooks (Prettier/ESLint) and passed; the change was committed as `feat: update release and determinism guidance`.
- No unit test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956fe3f0dc8832b82483018d964fa40)