### PR TITLE
chore: bump schema version to 3, extend instruction rendering and regenerate outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The master spec includes a `meta` block that defines system-wide expectations:
 
 ## Structure of `config/standards.json`
 
-- `version` — schema version (currently `2`)
+- `version` — schema version (currently `3`)
 - `meta` — global rules and migration policy
 - `ciSystems` — supported CI platforms
   _(currently `github-actions`, `azure-devops`)_
@@ -102,6 +102,7 @@ The `version` field indicates schema compatibility:
 
 - `1` — Original schema
 - `2` — Adds `bazelHints`, `meta.executorHints.bazel` for Bazel support, `anyOfFiles`, `pinningNotes`, enforcement/severity levels, ratio-based coverage thresholds, Rust/Go stacks. Enforces strict validation with `additionalProperties: false`.
+- `3` — Aligns schema major version with package major version.
 
 Consumers should ignore unknown fields for forward compatibility.
 

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["azure-devops"],

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["github-actions"],

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["azure-devops"],

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["github-actions"],

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.json
+++ b/config/standards.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "meta": {
     "defaultCoverageThreshold": 0.8,
     "coverageThresholdUnit": "ratio",

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["azure-devops"],

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["github-actions"],

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["azure-devops"],

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["github-actions"],

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["azure-devops"],

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["github-actions"],

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["azure-devops", "github-actions"],

--- a/instructions.csharp-dotnet.azure-devops.md
+++ b/instructions.csharp-dotnet.azure-devops.md
@@ -1,7 +1,7 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config/standards.csharp-dotnet.github-actions.json`
-> Stack: C# / .NET | CI: github-actions
+> Auto-generated from `config/standards.csharp-dotnet.azure-devops.json`
+> Stack: C# / .NET | CI: azure-devops
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
 

--- a/instructions.csharp-dotnet.azure-devops.md
+++ b/instructions.csharp-dotnet.azure-devops.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: .editorconfig must exist to drive the .NET formatting and analysis tooling.
 - Ensure .editorconfig exists in the repository.
-- Common tools: Roslyn analyzers, StyleCop. Example config files: .editorconfig, Directory.Build.props.
-- Consider adding Directory.Build.props if applicable.
+- Bazel commands: `bazel build //... --aspects=@rules_dotnet//dotnet:analyzers.bzl%analyzer_aspect`.
+- Example only; actual targets are repo-defined. Use rules_dotnet analyzer aspects for Roslyn-based linting.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test projects are present in the solution; test configuration is defined.
-- Common tools: xUnit, NUnit, MSTest. Example config files: \*.Tests.csproj.
-- Consider adding \*.Tests.csproj if applicable.
 - Bazel commands: `bazel test //...`.
+- Use rules_dotnet to define test targets for xUnit/NUnit/MSTest projects.
+- Common tools: xUnit, NUnit, MSTest. Example config files: \*.Tests.csproj.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the test suite with coverage enabled (for example, using coverlet or a similar tool) and verify that coverage reports are generated and used in CI to monitor thresholds.
-- Common tools: coverlet, ReportGenerator. Example config files: \*.csproj.
 - Bazel commands: `bazel coverage //...`.
 - Use rules_dotnet with coverage instrumentation enabled.
+- Common tools: coverlet, ReportGenerator. Example config files: \*.csproj.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs analyzers, tests, build, and any required packaging or container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Bazel handles all analysis, testing, and packaging via defined targets.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the configured formatter or code style enforcement (for example, `dotnet format`) and confirm that code in the repository conforms to the defined rules.
-- Common tools: dotnet format. Example config files: .editorconfig.
 - Bazel commands: `bazel run //tools/format:dotnet_format -- --verify-no-changes`.
 - Wrap dotnet format as a Bazel run target.
+- Common tools: dotnet format. Example config files: .editorconfig.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: .editorconfig must exist; Directory.Build.props is optional for shared build configuration.
 - Ensure .editorconfig exists in the repository.
-- Common tools: Roslyn analyzers. Example config files: .editorconfig, Directory.Build.props, \*.csproj.
-- Consider adding Directory.Build.props if applicable.
+- Bazel commands: `bazel build //...`.
+- Example only; actual targets are repo-defined. C# type errors surface during bazel build with rules_dotnet.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.csharp-dotnet.github-actions.md
+++ b/instructions.csharp-dotnet.github-actions.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: .editorconfig must exist to drive the .NET formatting and analysis tooling.
 - Ensure .editorconfig exists in the repository.
-- Common tools: Roslyn analyzers, StyleCop. Example config files: .editorconfig, Directory.Build.props.
-- Consider adding Directory.Build.props if applicable.
+- Bazel commands: `bazel build //... --aspects=@rules_dotnet//dotnet:analyzers.bzl%analyzer_aspect`.
+- Example only; actual targets are repo-defined. Use rules_dotnet analyzer aspects for Roslyn-based linting.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test projects are present in the solution; test configuration is defined.
-- Common tools: xUnit, NUnit, MSTest. Example config files: \*.Tests.csproj.
-- Consider adding \*.Tests.csproj if applicable.
 - Bazel commands: `bazel test //...`.
+- Use rules_dotnet to define test targets for xUnit/NUnit/MSTest projects.
+- Common tools: xUnit, NUnit, MSTest. Example config files: \*.Tests.csproj.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the test suite with coverage enabled (for example, using coverlet or a similar tool) and verify that coverage reports are generated and used in CI to monitor thresholds.
-- Common tools: coverlet, ReportGenerator. Example config files: \*.csproj.
 - Bazel commands: `bazel coverage //...`.
 - Use rules_dotnet with coverage instrumentation enabled.
+- Common tools: coverlet, ReportGenerator. Example config files: \*.csproj.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs analyzers, tests, build, and any required packaging or container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Bazel handles all analysis, testing, and packaging via defined targets.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the configured formatter or code style enforcement (for example, `dotnet format`) and confirm that code in the repository conforms to the defined rules.
-- Common tools: dotnet format. Example config files: .editorconfig.
 - Bazel commands: `bazel run //tools/format:dotnet_format -- --verify-no-changes`.
 - Wrap dotnet format as a Bazel run target.
+- Common tools: dotnet format. Example config files: .editorconfig.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: .editorconfig must exist; Directory.Build.props is optional for shared build configuration.
 - Ensure .editorconfig exists in the repository.
-- Common tools: Roslyn analyzers. Example config files: .editorconfig, Directory.Build.props, \*.csproj.
-- Consider adding Directory.Build.props if applicable.
+- Bazel commands: `bazel build //...`.
+- Example only; actual targets are repo-defined. C# type errors surface during bazel build with rules_dotnet.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.csharp-dotnet.md
+++ b/instructions.csharp-dotnet.md
@@ -1,7 +1,7 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config/standards.csharp-dotnet.github-actions.json`
-> Stack: C# / .NET | CI: github-actions
+> Auto-generated from `config/standards.csharp-dotnet.json`
+> Stack: C# / .NET | CI: azure-devops, github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
 

--- a/instructions.csharp-dotnet.md
+++ b/instructions.csharp-dotnet.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: .editorconfig must exist to drive the .NET formatting and analysis tooling.
 - Ensure .editorconfig exists in the repository.
-- Common tools: Roslyn analyzers, StyleCop. Example config files: .editorconfig, Directory.Build.props.
-- Consider adding Directory.Build.props if applicable.
+- Bazel commands: `bazel build //... --aspects=@rules_dotnet//dotnet:analyzers.bzl%analyzer_aspect`.
+- Example only; actual targets are repo-defined. Use rules_dotnet analyzer aspects for Roslyn-based linting.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test projects are present in the solution; test configuration is defined.
-- Common tools: xUnit, NUnit, MSTest. Example config files: \*.Tests.csproj.
-- Consider adding \*.Tests.csproj if applicable.
 - Bazel commands: `bazel test //...`.
+- Use rules_dotnet to define test targets for xUnit/NUnit/MSTest projects.
+- Common tools: xUnit, NUnit, MSTest. Example config files: \*.Tests.csproj.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the test suite with coverage enabled (for example, using coverlet or a similar tool) and verify that coverage reports are generated and used in CI to monitor thresholds.
-- Common tools: coverlet, ReportGenerator. Example config files: \*.csproj.
 - Bazel commands: `bazel coverage //...`.
 - Use rules_dotnet with coverage instrumentation enabled.
+- Common tools: coverlet, ReportGenerator. Example config files: \*.csproj.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs analyzers, tests, build, and any required packaging or container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Bazel handles all analysis, testing, and packaging via defined targets.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the configured formatter or code style enforcement (for example, `dotnet format`) and confirm that code in the repository conforms to the defined rules.
-- Common tools: dotnet format. Example config files: .editorconfig.
 - Bazel commands: `bazel run //tools/format:dotnet_format -- --verify-no-changes`.
 - Wrap dotnet format as a Bazel run target.
+- Common tools: dotnet format. Example config files: .editorconfig.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: .editorconfig must exist; Directory.Build.props is optional for shared build configuration.
 - Ensure .editorconfig exists in the repository.
-- Common tools: Roslyn analyzers. Example config files: .editorconfig, Directory.Build.props, \*.csproj.
-- Consider adding Directory.Build.props if applicable.
+- Bazel commands: `bazel build //...`.
+- Example only; actual targets are repo-defined. C# type errors surface during bazel build with rules_dotnet.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.go.azure-devops.md
+++ b/instructions.go.azure-devops.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: .golangci.yml or .golangci.yaml indicates linting is configured. Run 'golangci-lint run' to verify.
 - Ensure go.mod exists in the repository.
-- Common tools: golangci-lint, staticcheck. Example config files: .golangci.yml, .golangci.yaml.
-- Consider adding .golangci.yml, .golangci.yaml if applicable.
+- Bazel commands: `bazel test //... --@io_bazel_rules_go//go/config:nogo=@//:nogo`.
+- Use nogo for static analysis via rules_go. Configure nogo target with desired analyzers.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Run 'go test ./...' to verify the test suite is configured and passing.
 - Ensure go.mod exists in the repository.
-- Common tools: go test. Example config files: go.mod.
 - Bazel commands: `bazel test //...`.
+- rules_go go_test targets wrap 'go test' with Bazel's caching and hermeticity.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -57,25 +57,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run 'go test -cover ./...' and verify coverage reports are produced and thresholds monitored.
-- Common tools: go test -cover, go tool cover. Example config files: go.mod.
 - Bazel commands: `bazel coverage //...`.
 - rules_go supports coverage via bazel coverage. Use --combined_report=lcov for aggregated output.
+- Common tools: go test -cover, go tool cover. Example config files: go.mod.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Verify CI runs golangci-lint, go test, and go build before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - rules_go go_binary and go_test targets provide hermetic builds and tests.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run 'gofmt -d .' or 'goimports -d .' and confirm no output indicates clean formatting.
-- Common tools: gofmt, goimports.
 - Bazel commands: `bazel run @go_sdk//:bin/gofmt -- -d .`.
 - Run gofmt via the Bazel-managed Go SDK for hermetic formatting checks.
+- Common tools: gofmt, goimports.
 
 ### Pre-Commit Hooks
 
@@ -89,8 +89,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: Run 'go build ./...' to verify type correctness. Use 'go vet ./...' for additional static analysis.
 - Ensure go.mod exists in the repository.
-- Common tools: go vet, staticcheck. Example config files: go.mod.
 - Bazel commands: `bazel build //...`.
+- Go type checking is inherent to compilation. bazel build with rules_go enforces type safety.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.go.azure-devops.md
+++ b/instructions.go.azure-devops.md
@@ -1,0 +1,178 @@
+# Repository Standards Instructions
+
+> Auto-generated from `config/standards.go.azure-devops.json`
+> Stack: Go | CI: azure-devops
+
+This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
+
+## Core Requirements
+
+### Git and Docker Ignore Files
+
+- Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
+- Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
+- Consider adding .dockerignore if applicable.
+
+### Linting
+
+- Run static code linting to enforce consistency and catch common issues early.
+- Verify with: .golangci.yml or .golangci.yaml indicates linting is configured. Run 'golangci-lint run' to verify.
+- Ensure go.mod exists in the repository.
+- Common tools: golangci-lint, staticcheck. Example config files: .golangci.yml, .golangci.yaml.
+- Consider adding .golangci.yml, .golangci.yaml if applicable.
+
+### Unit Test Runner
+
+- Provide a deterministic unit test framework with a single command to run all tests.
+- Verify with: Run 'go test ./...' to verify the test suite is configured and passing.
+- Ensure go.mod exists in the repository.
+- Common tools: go test. Example config files: go.mod.
+- Bazel commands: `bazel test //...`.
+
+### Containerization (Docker / Docker Compose)
+
+- Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
+- Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
+- Consider adding docker-compose.yml if applicable.
+
+### Semantic Versioning
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Verify with: Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs.
+- Common tools: goreleaser, semantic-release. Example config files: .goreleaser.yml, CHANGELOG.md.
+- Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.
+
+### Commit Linting
+
+- Enforce structured commit messages such as Conventional Commits.
+- Verify with: Test that non-conforming commit messages are rejected by the configured hooks or CI check.
+- Common tools: commitlint, commitizen. Example config files: commitlint.config.js, .cz.toml.
+- Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.
+
+### Unit Test Reporter / Coverage
+
+- Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
+- Verify with: Run 'go test -cover ./...' and verify coverage reports are produced and thresholds monitored.
+- Common tools: go test -cover, go tool cover. Example config files: go.mod.
+- Bazel commands: `bazel coverage //...`.
+- rules_go supports coverage via bazel coverage. Use --combined_report=lcov for aggregated output.
+
+### CI Quality Gates
+
+- Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
+- Verify with: Verify CI runs golangci-lint, go test, and go build before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- rules_go go_binary and go_test targets provide hermetic builds and tests.
+
+### Code Formatter
+
+- Automatic code formatting to maintain a consistent style across all contributors.
+- Verify with: Run 'gofmt -d .' or 'goimports -d .' and confirm no output indicates clean formatting.
+- Common tools: gofmt, goimports.
+- Bazel commands: `bazel run @go_sdk//:bin/gofmt -- -d .`.
+- Run gofmt via the Bazel-managed Go SDK for hermetic formatting checks.
+
+### Pre-Commit Hooks
+
+- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect hooks configuration and confirm that go fmt and golangci-lint run before commits.
+- Common tools: pre-commit, lefthook. Example config files: .pre-commit-config.yaml, lefthook.yml.
+- Use pre-commit with go hooks for gofmt, goimports, and golangci-lint on staged files.
+
+### Type Checking
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: Run 'go build ./...' to verify type correctness. Use 'go vet ./...' for additional static analysis.
+- Ensure go.mod exists in the repository.
+- Common tools: go vet, staticcheck. Example config files: go.mod.
+- Bazel commands: `bazel build //...`.
+
+### Dependency Management & Vulnerability Scanning
+
+- Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: go.sum is present; run 'govulncheck ./...' to verify security scanning.
+- Ensure go.sum exists in the repository.
+- Common tools: govulncheck, nancy. Example config files: go.sum.
+- Use govulncheck (official Go tool) for vulnerability scanning. go.sum locks dependency checksums for reproducible builds.
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: go.mod must contain 'go' directive specifying minimum version; .go-version is optional for local development.
+- Ensure go.mod exists in the repository.
+- Example config files: go.mod, .go-version.
+- Consider adding .go-version if applicable.
+
+### Documentation Standards
+
+- Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present; documentation comments exist in exported functions/types.
+- Ensure README.md exists in the repository.
+- Common tools: godoc, pkgsite. Example config files: README.md, docs/.
+- Consider adding docs/ if applicable.
+
+### Repository Governance
+
+- Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present; CODE_OF_CONDUCT.md and CONTRIBUTING.md provide contribution guidance.
+- Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
+- Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
+
+## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json OR .github/dependabot.yml. Verify Go module PRs.
+- Ensure at least one of renovate.json, .renovaterc.json, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Both support go.mod/go.sum. Renovate handles replace directives better. Security scanning is covered by dependency-security (govulncheck).
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'go mod verify' and 'go mod tidy' with diff check in CI.
+- Common tools: depaware, go-mod-check.
+
+### Integration Testing
+
+- Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm integration tests exist and run 'go test -tags=integration ./...' to verify.
+- Common tools: go test. Example config files: \*\_test.go.
+- Use build tags (//go:build integration) or separate test directories for integration tests. Run with 'go test -tags=integration ./...'.
+
+### Performance Baselines
+
+- Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Run 'go test -bench=. ./...' and verify benchmark results are tracked over time.
+- Common tools: go test -bench, benchstat. Example config files: \*\_test.go.
+- Use 'go test -bench=. ./...' for benchmarks. Use benchstat to compare results across runs.
+
+### Complexity Analysis
+
+- Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run 'gocyclo' or 'golangci-lint run' and review complexity reports, ensuring new code doesn't exceed thresholds.
+- Common tools: gocyclo, golangci-lint. Example config files: .golangci.yml.
+- Use gocyclo or golangci-lint's gocyclo linter to measure cyclomatic complexity. Configure threshold in .golangci.yml.
+
+### Accessibility Auditing
+
+- Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For web-facing Go apps, run accessibility audits against key routes using axe or pa11y.
+- Common tools: axe-core, pa11y.
+- For Go web apps, use headless browser-based accessibility tools to audit rendered HTML from templates.
+
+## Optional Enhancements
+
+### Observability (Logging & Error Handling)
+
+- Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that a structured logging library is configured with appropriate output format and log levels.
+- Common tools: slog, zap, zerolog.
+- Use slog (stdlib) or zap/zerolog for structured logging. Configure JSON output for production and text for development.

--- a/instructions.go.github-actions.md
+++ b/instructions.go.github-actions.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: .golangci.yml or .golangci.yaml indicates linting is configured. Run 'golangci-lint run' to verify.
 - Ensure go.mod exists in the repository.
-- Common tools: golangci-lint, staticcheck. Example config files: .golangci.yml, .golangci.yaml.
-- Consider adding .golangci.yml, .golangci.yaml if applicable.
+- Bazel commands: `bazel test //... --@io_bazel_rules_go//go/config:nogo=@//:nogo`.
+- Use nogo for static analysis via rules_go. Configure nogo target with desired analyzers.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Run 'go test ./...' to verify the test suite is configured and passing.
 - Ensure go.mod exists in the repository.
-- Common tools: go test. Example config files: go.mod.
 - Bazel commands: `bazel test //...`.
+- rules_go go_test targets wrap 'go test' with Bazel's caching and hermeticity.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -57,25 +57,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run 'go test -cover ./...' and verify coverage reports are produced and thresholds monitored.
-- Common tools: go test -cover, go tool cover. Example config files: go.mod.
 - Bazel commands: `bazel coverage //...`.
 - rules_go supports coverage via bazel coverage. Use --combined_report=lcov for aggregated output.
+- Common tools: go test -cover, go tool cover. Example config files: go.mod.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Verify CI runs golangci-lint, go test, and go build before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - rules_go go_binary and go_test targets provide hermetic builds and tests.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run 'gofmt -d .' or 'goimports -d .' and confirm no output indicates clean formatting.
-- Common tools: gofmt, goimports.
 - Bazel commands: `bazel run @go_sdk//:bin/gofmt -- -d .`.
 - Run gofmt via the Bazel-managed Go SDK for hermetic formatting checks.
+- Common tools: gofmt, goimports.
 
 ### Pre-Commit Hooks
 
@@ -89,8 +89,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: Run 'go build ./...' to verify type correctness. Use 'go vet ./...' for additional static analysis.
 - Ensure go.mod exists in the repository.
-- Common tools: go vet, staticcheck. Example config files: go.mod.
 - Bazel commands: `bazel build //...`.
+- Go type checking is inherent to compilation. bazel build with rules_go enforces type safety.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.go.github-actions.md
+++ b/instructions.go.github-actions.md
@@ -1,0 +1,178 @@
+# Repository Standards Instructions
+
+> Auto-generated from `config/standards.go.github-actions.json`
+> Stack: Go | CI: github-actions
+
+This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
+
+## Core Requirements
+
+### Git and Docker Ignore Files
+
+- Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
+- Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
+- Consider adding .dockerignore if applicable.
+
+### Linting
+
+- Run static code linting to enforce consistency and catch common issues early.
+- Verify with: .golangci.yml or .golangci.yaml indicates linting is configured. Run 'golangci-lint run' to verify.
+- Ensure go.mod exists in the repository.
+- Common tools: golangci-lint, staticcheck. Example config files: .golangci.yml, .golangci.yaml.
+- Consider adding .golangci.yml, .golangci.yaml if applicable.
+
+### Unit Test Runner
+
+- Provide a deterministic unit test framework with a single command to run all tests.
+- Verify with: Run 'go test ./...' to verify the test suite is configured and passing.
+- Ensure go.mod exists in the repository.
+- Common tools: go test. Example config files: go.mod.
+- Bazel commands: `bazel test //...`.
+
+### Containerization (Docker / Docker Compose)
+
+- Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
+- Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
+- Consider adding docker-compose.yml if applicable.
+
+### Semantic Versioning
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Verify with: Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs.
+- Common tools: goreleaser, semantic-release. Example config files: .goreleaser.yml, CHANGELOG.md.
+- Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.
+
+### Commit Linting
+
+- Enforce structured commit messages such as Conventional Commits.
+- Verify with: Test that non-conforming commit messages are rejected by the configured hooks or CI check.
+- Common tools: commitlint, commitizen. Example config files: commitlint.config.js, .cz.toml.
+- Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.
+
+### Unit Test Reporter / Coverage
+
+- Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
+- Verify with: Run 'go test -cover ./...' and verify coverage reports are produced and thresholds monitored.
+- Common tools: go test -cover, go tool cover. Example config files: go.mod.
+- Bazel commands: `bazel coverage //...`.
+- rules_go supports coverage via bazel coverage. Use --combined_report=lcov for aggregated output.
+
+### CI Quality Gates
+
+- Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
+- Verify with: Verify CI runs golangci-lint, go test, and go build before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- rules_go go_binary and go_test targets provide hermetic builds and tests.
+
+### Code Formatter
+
+- Automatic code formatting to maintain a consistent style across all contributors.
+- Verify with: Run 'gofmt -d .' or 'goimports -d .' and confirm no output indicates clean formatting.
+- Common tools: gofmt, goimports.
+- Bazel commands: `bazel run @go_sdk//:bin/gofmt -- -d .`.
+- Run gofmt via the Bazel-managed Go SDK for hermetic formatting checks.
+
+### Pre-Commit Hooks
+
+- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect hooks configuration and confirm that go fmt and golangci-lint run before commits.
+- Common tools: pre-commit, lefthook. Example config files: .pre-commit-config.yaml, lefthook.yml.
+- Use pre-commit with go hooks for gofmt, goimports, and golangci-lint on staged files.
+
+### Type Checking
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: Run 'go build ./...' to verify type correctness. Use 'go vet ./...' for additional static analysis.
+- Ensure go.mod exists in the repository.
+- Common tools: go vet, staticcheck. Example config files: go.mod.
+- Bazel commands: `bazel build //...`.
+
+### Dependency Management & Vulnerability Scanning
+
+- Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: go.sum is present; run 'govulncheck ./...' to verify security scanning.
+- Ensure go.sum exists in the repository.
+- Common tools: govulncheck, nancy. Example config files: go.sum.
+- Use govulncheck (official Go tool) for vulnerability scanning. go.sum locks dependency checksums for reproducible builds.
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: go.mod must contain 'go' directive specifying minimum version; .go-version is optional for local development.
+- Ensure go.mod exists in the repository.
+- Example config files: go.mod, .go-version.
+- Consider adding .go-version if applicable.
+
+### Documentation Standards
+
+- Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present; documentation comments exist in exported functions/types.
+- Ensure README.md exists in the repository.
+- Common tools: godoc, pkgsite. Example config files: README.md, docs/.
+- Consider adding docs/ if applicable.
+
+### Repository Governance
+
+- Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present; CODE_OF_CONDUCT.md and CONTRIBUTING.md provide contribution guidance.
+- Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
+- Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
+
+## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json OR .github/dependabot.yml. Verify Go module PRs.
+- Ensure at least one of renovate.json, .renovaterc.json, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Both support go.mod/go.sum. Renovate handles replace directives better. Security scanning is covered by dependency-security (govulncheck).
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'go mod verify' and 'go mod tidy' with diff check in CI.
+- Common tools: depaware, go-mod-check.
+
+### Integration Testing
+
+- Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm integration tests exist and run 'go test -tags=integration ./...' to verify.
+- Common tools: go test. Example config files: \*\_test.go.
+- Use build tags (//go:build integration) or separate test directories for integration tests. Run with 'go test -tags=integration ./...'.
+
+### Performance Baselines
+
+- Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Run 'go test -bench=. ./...' and verify benchmark results are tracked over time.
+- Common tools: go test -bench, benchstat. Example config files: \*\_test.go.
+- Use 'go test -bench=. ./...' for benchmarks. Use benchstat to compare results across runs.
+
+### Complexity Analysis
+
+- Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run 'gocyclo' or 'golangci-lint run' and review complexity reports, ensuring new code doesn't exceed thresholds.
+- Common tools: gocyclo, golangci-lint. Example config files: .golangci.yml.
+- Use gocyclo or golangci-lint's gocyclo linter to measure cyclomatic complexity. Configure threshold in .golangci.yml.
+
+### Accessibility Auditing
+
+- Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For web-facing Go apps, run accessibility audits against key routes using axe or pa11y.
+- Common tools: axe-core, pa11y.
+- For Go web apps, use headless browser-based accessibility tools to audit rendered HTML from templates.
+
+## Optional Enhancements
+
+### Observability (Logging & Error Handling)
+
+- Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that a structured logging library is configured with appropriate output format and log levels.
+- Common tools: slog, zap, zerolog.
+- Use slog (stdlib) or zap/zerolog for structured logging. Configure JSON output for production and text for development.

--- a/instructions.go.md
+++ b/instructions.go.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: .golangci.yml or .golangci.yaml indicates linting is configured. Run 'golangci-lint run' to verify.
 - Ensure go.mod exists in the repository.
-- Common tools: golangci-lint, staticcheck. Example config files: .golangci.yml, .golangci.yaml.
-- Consider adding .golangci.yml, .golangci.yaml if applicable.
+- Bazel commands: `bazel test //... --@io_bazel_rules_go//go/config:nogo=@//:nogo`.
+- Use nogo for static analysis via rules_go. Configure nogo target with desired analyzers.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Run 'go test ./...' to verify the test suite is configured and passing.
 - Ensure go.mod exists in the repository.
-- Common tools: go test. Example config files: go.mod.
 - Bazel commands: `bazel test //...`.
+- rules_go go_test targets wrap 'go test' with Bazel's caching and hermeticity.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -57,25 +57,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run 'go test -cover ./...' and verify coverage reports are produced and thresholds monitored.
-- Common tools: go test -cover, go tool cover. Example config files: go.mod.
 - Bazel commands: `bazel coverage //...`.
 - rules_go supports coverage via bazel coverage. Use --combined_report=lcov for aggregated output.
+- Common tools: go test -cover, go tool cover. Example config files: go.mod.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Verify CI runs golangci-lint, go test, and go build before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - rules_go go_binary and go_test targets provide hermetic builds and tests.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run 'gofmt -d .' or 'goimports -d .' and confirm no output indicates clean formatting.
-- Common tools: gofmt, goimports.
 - Bazel commands: `bazel run @go_sdk//:bin/gofmt -- -d .`.
 - Run gofmt via the Bazel-managed Go SDK for hermetic formatting checks.
+- Common tools: gofmt, goimports.
 
 ### Pre-Commit Hooks
 
@@ -89,8 +89,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: Run 'go build ./...' to verify type correctness. Use 'go vet ./...' for additional static analysis.
 - Ensure go.mod exists in the repository.
-- Common tools: go vet, staticcheck. Example config files: go.mod.
 - Bazel commands: `bazel build //...`.
+- Go type checking is inherent to compilation. bazel build with rules_go enforces type safety.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.go.md
+++ b/instructions.go.md
@@ -1,0 +1,178 @@
+# Repository Standards Instructions
+
+> Auto-generated from `config/standards.go.json`
+> Stack: Go | CI: azure-devops, github-actions
+
+This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
+
+## Core Requirements
+
+### Git and Docker Ignore Files
+
+- Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
+- Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
+- Consider adding .dockerignore if applicable.
+
+### Linting
+
+- Run static code linting to enforce consistency and catch common issues early.
+- Verify with: .golangci.yml or .golangci.yaml indicates linting is configured. Run 'golangci-lint run' to verify.
+- Ensure go.mod exists in the repository.
+- Common tools: golangci-lint, staticcheck. Example config files: .golangci.yml, .golangci.yaml.
+- Consider adding .golangci.yml, .golangci.yaml if applicable.
+
+### Unit Test Runner
+
+- Provide a deterministic unit test framework with a single command to run all tests.
+- Verify with: Run 'go test ./...' to verify the test suite is configured and passing.
+- Ensure go.mod exists in the repository.
+- Common tools: go test. Example config files: go.mod.
+- Bazel commands: `bazel test //...`.
+
+### Containerization (Docker / Docker Compose)
+
+- Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
+- Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
+- Consider adding docker-compose.yml if applicable.
+
+### Semantic Versioning
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Verify with: Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs.
+- Common tools: goreleaser, semantic-release. Example config files: .goreleaser.yml, CHANGELOG.md.
+- Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.
+
+### Commit Linting
+
+- Enforce structured commit messages such as Conventional Commits.
+- Verify with: Test that non-conforming commit messages are rejected by the configured hooks or CI check.
+- Common tools: commitlint, commitizen. Example config files: commitlint.config.js, .cz.toml.
+- Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.
+
+### Unit Test Reporter / Coverage
+
+- Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
+- Verify with: Run 'go test -cover ./...' and verify coverage reports are produced and thresholds monitored.
+- Common tools: go test -cover, go tool cover. Example config files: go.mod.
+- Bazel commands: `bazel coverage //...`.
+- rules_go supports coverage via bazel coverage. Use --combined_report=lcov for aggregated output.
+
+### CI Quality Gates
+
+- Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
+- Verify with: Verify CI runs golangci-lint, go test, and go build before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- rules_go go_binary and go_test targets provide hermetic builds and tests.
+
+### Code Formatter
+
+- Automatic code formatting to maintain a consistent style across all contributors.
+- Verify with: Run 'gofmt -d .' or 'goimports -d .' and confirm no output indicates clean formatting.
+- Common tools: gofmt, goimports.
+- Bazel commands: `bazel run @go_sdk//:bin/gofmt -- -d .`.
+- Run gofmt via the Bazel-managed Go SDK for hermetic formatting checks.
+
+### Pre-Commit Hooks
+
+- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect hooks configuration and confirm that go fmt and golangci-lint run before commits.
+- Common tools: pre-commit, lefthook. Example config files: .pre-commit-config.yaml, lefthook.yml.
+- Use pre-commit with go hooks for gofmt, goimports, and golangci-lint on staged files.
+
+### Type Checking
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: Run 'go build ./...' to verify type correctness. Use 'go vet ./...' for additional static analysis.
+- Ensure go.mod exists in the repository.
+- Common tools: go vet, staticcheck. Example config files: go.mod.
+- Bazel commands: `bazel build //...`.
+
+### Dependency Management & Vulnerability Scanning
+
+- Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: go.sum is present; run 'govulncheck ./...' to verify security scanning.
+- Ensure go.sum exists in the repository.
+- Common tools: govulncheck, nancy. Example config files: go.sum.
+- Use govulncheck (official Go tool) for vulnerability scanning. go.sum locks dependency checksums for reproducible builds.
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: go.mod must contain 'go' directive specifying minimum version; .go-version is optional for local development.
+- Ensure go.mod exists in the repository.
+- Example config files: go.mod, .go-version.
+- Consider adding .go-version if applicable.
+
+### Documentation Standards
+
+- Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present; documentation comments exist in exported functions/types.
+- Ensure README.md exists in the repository.
+- Common tools: godoc, pkgsite. Example config files: README.md, docs/.
+- Consider adding docs/ if applicable.
+
+### Repository Governance
+
+- Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present; CODE_OF_CONDUCT.md and CONTRIBUTING.md provide contribution guidance.
+- Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
+- Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
+
+## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json OR .github/dependabot.yml. Verify Go module PRs.
+- Ensure at least one of renovate.json, .renovaterc.json, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Both support go.mod/go.sum. Renovate handles replace directives better. Security scanning is covered by dependency-security (govulncheck).
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'go mod verify' and 'go mod tidy' with diff check in CI.
+- Common tools: depaware, go-mod-check.
+
+### Integration Testing
+
+- Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm integration tests exist and run 'go test -tags=integration ./...' to verify.
+- Common tools: go test. Example config files: \*\_test.go.
+- Use build tags (//go:build integration) or separate test directories for integration tests. Run with 'go test -tags=integration ./...'.
+
+### Performance Baselines
+
+- Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Run 'go test -bench=. ./...' and verify benchmark results are tracked over time.
+- Common tools: go test -bench, benchstat. Example config files: \*\_test.go.
+- Use 'go test -bench=. ./...' for benchmarks. Use benchstat to compare results across runs.
+
+### Complexity Analysis
+
+- Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run 'gocyclo' or 'golangci-lint run' and review complexity reports, ensuring new code doesn't exceed thresholds.
+- Common tools: gocyclo, golangci-lint. Example config files: .golangci.yml.
+- Use gocyclo or golangci-lint's gocyclo linter to measure cyclomatic complexity. Configure threshold in .golangci.yml.
+
+### Accessibility Auditing
+
+- Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For web-facing Go apps, run accessibility audits against key routes using axe or pa11y.
+- Common tools: axe-core, pa11y.
+- For Go web apps, use headless browser-based accessibility tools to audit rendered HTML from templates.
+
+## Optional Enhancements
+
+### Observability (Logging & Error Handling)
+
+- Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that a structured logging library is configured with appropriate output format and log levels.
+- Common tools: slog, zap, zerolog.
+- Use slog (stdlib) or zap/zerolog for structured logging. Configure JSON output for production and text for development.

--- a/instructions.md
+++ b/instructions.md
@@ -21,15 +21,15 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of eslint.config.js (or any .eslintrc\* file) indicates linting is enforced for the repository.
 - Ensure at least one of eslint.config.js, eslint.config.mjs, eslint.config.cjs, .eslintrc.js, .eslintrc.cjs, .eslintrc.json, .eslintrc.yaml, .eslintrc.yml is present.
 - Define a `lint` script or equivalent command.
-- Common tools: eslint. Example config files: .eslintrc.\*, eslint.config.js.
+- Bazel commands: `bazel test //... --aspects=//tools:lint.bzl%eslint_aspect --output_groups=report`.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test framework configuration is present; test script is defined in package.json.
 - Define a `test` script or equivalent command.
-- Common tools: jest. Example config files: jest.config.\*.
-- Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
+- Bazel commands: `bazel test //...`.
+- Bazel discovers and runs all test targets. Use rules_js for Jest/Vitest integration.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the unit tests with coverage enabled and confirm that a coverage report is produced and that the configured threshold (around 80%) is enforced for new changes.
-- Common tools: jest, nyc. Example config files: jest.config.\*.
 - Bazel commands: `bazel coverage //...`.
 - Bazel coverage collects coverage data from all test targets. Use --combined_report=lcov for aggregated reports.
+- Common tools: jest, nyc. Example config files: jest.config.\*.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking, tests, build, and any required container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Replace npm run ci with Bazel commands. All quality gates run as Bazel targets.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the formatter in check mode (for example, `npm run format:check`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
-- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 - Bazel commands: `bazel run //tools/format:check`, `bazel test //...:format_test`.
 - Wrap Prettier as a run target for formatting checks. Use aspect_rules_lint for format aspects.
+- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 
 ### Pre-Commit Hooks
 
@@ -89,7 +89,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of tsconfig.json indicates type-checking is configured for the repository.
 - Ensure tsconfig.json exists in the repository.
 - Define a `typecheck` script or equivalent command.
-- Common tools: TypeScript compiler (tsc). Example config files: tsconfig.json.
+- Bazel commands: `bazel build //...`.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.python.azure-devops.md
+++ b/instructions.python.azure-devops.md
@@ -1,7 +1,7 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config/standards.python.github-actions.json`
-> Stack: Python | CI: github-actions
+> Auto-generated from `config/standards.python.azure-devops.json`
+> Stack: Python | CI: azure-devops
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
 

--- a/instructions.python.azure-devops.md
+++ b/instructions.python.azure-devops.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: pyproject.toml (or ruff.toml / .flake8 / setup.cfg) signals that linting tools are configured for the repository.
 - Ensure at least one of pyproject.toml, ruff.toml, .flake8, setup.cfg, tox.ini is present.
-- Common tools: ruff, flake8. Example config files: pyproject.toml, .flake8, ruff.toml.
 - Bazel commands: `bazel test //...:ruff_test`, `bazel run //tools/lint:ruff -- check .`.
+- Example only; actual targets are repo-defined. Use rules_python with ruff wrapped as py_test or run target.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test framework configuration is present; tests/ directory or pytest configuration exists.
-- Common tools: pytest. Example config files: pytest.ini, pyproject.toml.
-- Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
 - Bazel commands: `bazel test //...`.
+- Example only; actual targets are repo-defined. Use rules_python py_test for pytest-based tests.
+- Common tools: pytest. Example config files: pytest.ini, pyproject.toml.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the unit tests with coverage (for example, pytest with pytest-cov) and confirm that coverage reports are generated and referenced in CI to enforce or track thresholds.
-- Common tools: pytest, pytest-cov, coverage.py. Example config files: pytest.ini, pyproject.toml.
 - Bazel commands: `bazel coverage //...`.
 - Use rules_python py_test with coverage instrumentation. Combine with --combined_report=lcov.
+- Common tools: pytest, pytest-cov, coverage.py. Example config files: pytest.ini, pyproject.toml.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking (if used), tests, and any packaging or container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Bazel py_binary and py_test targets replace traditional Python tooling.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the configured formatter (for example, `black .` or `black --check .`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
-- Common tools: black. Example config files: pyproject.toml.
 - Bazel commands: `bazel run //tools/format:black -- --check .`.
 - Wrap black as a py_binary run target for format checking.
+- Common tools: black. Example config files: pyproject.toml.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: pyproject.toml (or mypy.ini) signals that mypy configuration is available for the repository.
 - Ensure pyproject.toml exists in the repository.
-- Common tools: mypy. Example config files: mypy.ini, pyproject.toml.
-- Consider adding mypy.ini if applicable.
+- Bazel commands: `bazel test //...:mypy_test`, `bazel run //tools/typecheck:mypy`.
+- Example only; actual targets are repo-defined. Wrap mypy as a py_test or run target.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.python.github-actions.md
+++ b/instructions.python.github-actions.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: pyproject.toml (or ruff.toml / .flake8 / setup.cfg) signals that linting tools are configured for the repository.
 - Ensure at least one of pyproject.toml, ruff.toml, .flake8, setup.cfg, tox.ini is present.
-- Common tools: ruff, flake8. Example config files: pyproject.toml, .flake8, ruff.toml.
 - Bazel commands: `bazel test //...:ruff_test`, `bazel run //tools/lint:ruff -- check .`.
+- Example only; actual targets are repo-defined. Use rules_python with ruff wrapped as py_test or run target.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test framework configuration is present; tests/ directory or pytest configuration exists.
-- Common tools: pytest. Example config files: pytest.ini, pyproject.toml.
-- Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
 - Bazel commands: `bazel test //...`.
+- Example only; actual targets are repo-defined. Use rules_python py_test for pytest-based tests.
+- Common tools: pytest. Example config files: pytest.ini, pyproject.toml.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the unit tests with coverage (for example, pytest with pytest-cov) and confirm that coverage reports are generated and referenced in CI to enforce or track thresholds.
-- Common tools: pytest, pytest-cov, coverage.py. Example config files: pytest.ini, pyproject.toml.
 - Bazel commands: `bazel coverage //...`.
 - Use rules_python py_test with coverage instrumentation. Combine with --combined_report=lcov.
+- Common tools: pytest, pytest-cov, coverage.py. Example config files: pytest.ini, pyproject.toml.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking (if used), tests, and any packaging or container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Bazel py_binary and py_test targets replace traditional Python tooling.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the configured formatter (for example, `black .` or `black --check .`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
-- Common tools: black. Example config files: pyproject.toml.
 - Bazel commands: `bazel run //tools/format:black -- --check .`.
 - Wrap black as a py_binary run target for format checking.
+- Common tools: black. Example config files: pyproject.toml.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: pyproject.toml (or mypy.ini) signals that mypy configuration is available for the repository.
 - Ensure pyproject.toml exists in the repository.
-- Common tools: mypy. Example config files: mypy.ini, pyproject.toml.
-- Consider adding mypy.ini if applicable.
+- Bazel commands: `bazel test //...:mypy_test`, `bazel run //tools/typecheck:mypy`.
+- Example only; actual targets are repo-defined. Wrap mypy as a py_test or run target.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.python.md
+++ b/instructions.python.md
@@ -1,6 +1,6 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config\standards.python.json`
+> Auto-generated from `config/standards.python.json`
 > Stack: Python | CI: azure-devops, github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
@@ -10,109 +10,163 @@ This document provides high-level guidance for an autonomous coding agent to bri
 ### Git and Docker Ignore Files
 
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
 - Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
 - Consider adding .dockerignore if applicable.
 
 ### Linting
 
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure pyproject.toml exists in the repository.
-- Consider adding ruff.toml, .flake8 if applicable.
-- Define a `lint` script in package.json or equivalent.
-- Configure a primary linter (such as ruff) and keep rules focused on catching real issues without overwhelming developers.
+- Verify with: pyproject.toml (or ruff.toml / .flake8 / setup.cfg) signals that linting tools are configured for the repository.
+- Ensure at least one of pyproject.toml, ruff.toml, .flake8, setup.cfg, tox.ini is present.
+- Common tools: ruff, flake8. Example config files: pyproject.toml, .flake8, ruff.toml.
+- Bazel commands: `bazel test //...:ruff_test`, `bazel run //tools/lint:ruff -- check .`.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
+- Verify with: Test framework configuration is present; tests/ directory or pytest configuration exists.
+- Common tools: pytest. Example config files: pytest.ini, pyproject.toml.
 - Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
-- Define a `test` script in package.json or equivalent.
-- Organize unit tests under a tests/ directory and avoid real network or database calls in this layer.
+- Bazel commands: `bazel test //...`.
 
 ### Containerization (Docker / Docker Compose)
 
 - Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
 - Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
 - Consider adding docker-compose.yml if applicable.
-- Choose a slim Python base image, pin the version, and clearly document how to start the service in a container.
 
 ### Semantic Versioning
 
 - Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
-- Use a single source of truth for the package version and keep it aligned with SemVer and your release notes.
+- Verify with: Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments.
+- Common tools: bumpversion, setuptools_scm, towncrier. Example config files: pyproject.toml, setup.cfg, CHANGELOG.md.
 
 ### Commit Linting
 
 - Enforce structured commit messages such as Conventional Commits.
+- Verify with: Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted.
+- Common tools: commitizen. Example config files: .cz.toml, pyproject.toml.
 - Standardize commit messages using commitizen or a similar helper and document the required types and scopes.
 
 ### Unit Test Reporter / Coverage
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
-- Configure coverage reporting for your test suite and surface summary metrics in CI.
+- Verify with: Run the unit tests with coverage (for example, pytest with pytest-cov) and confirm that coverage reports are generated and referenced in CI to enforce or track thresholds.
+- Common tools: pytest, pytest-cov, coverage.py. Example config files: pytest.ini, pyproject.toml.
+- Bazel commands: `bazel coverage //...`.
+- Use rules_python py_test with coverage instrumentation. Combine with --combined_report=lcov.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
-- Ensure CI runs linting, type checking (if used), tests, and packaging or container checks for Python services before merging.
+- Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking (if used), tests, and any packaging or container checks before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- Bazel py_binary and py_test targets replace traditional Python tooling.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
-- Use black (or an equivalent opinionated formatter) and treat its output as the single source of truth for code style.
+- Verify with: Run the configured formatter (for example, `black .` or `black --check .`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
+- Common tools: black. Example config files: pyproject.toml.
+- Bazel commands: `bazel run //tools/format:black -- --check .`.
+- Wrap black as a py_binary run target for format checking.
 
 ### Pre-Commit Hooks
 
 - Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect .pre-commit-config.yaml and confirm that hooks for linting, formatting, and optionally type checking are enabled and run on changed files before commits.
+- Common tools: pre-commit. Example config files: .pre-commit-config.yaml.
 - Use pre-commit to run ruff, black, and optionally mypy on staged files before committing.
 
 ### Type Checking
 
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: pyproject.toml (or mypy.ini) signals that mypy configuration is available for the repository.
 - Ensure pyproject.toml exists in the repository.
+- Common tools: mypy. Example config files: mypy.ini, pyproject.toml.
 - Consider adding mypy.ini if applicable.
-- Define a `typecheck` script in package.json or equivalent.
-- Adopt gradual typing with type hints and mypy, focusing first on critical modules and new code paths.
 
 ### Dependency Management & Vulnerability Scanning
 
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: Dependency lockfile is present; security scanning is configured in CI or project tooling.
+- Common tools: pip-audit, safety. Example config files: requirements.txt, Pipfile.lock, poetry.lock.
 - Consider adding requirements.txt, Pipfile.lock, poetry.lock if applicable.
 - Pin dependency versions and routinely scan for vulnerabilities, prioritizing fixes for critical and high-severity issues.
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: pyproject.toml or setup.py must specify python_requires; .python-version is recommended for local development.
+- Ensure pyproject.toml exists in the repository.
+- Example config files: pyproject.toml, setup.py, .python-version.
+- Consider adding .python-version if applicable.
 
 ### Documentation Standards
 
 - Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present in the repository root; docs/ directory or documentation tooling configuration exists if applicable.
 - Ensure README.md exists in the repository.
+- Common tools: Sphinx, MkDocs. Example config files: README.md, docs/.
 - Consider adding docs/, mkdocs.yml if applicable.
-- Ensure README explains environment setup and core commands, and generate API docs from docstrings where appropriate.
 
 ### Repository Governance
 
 - Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present in the repository root; CODE_OF_CONDUCT.md and CONTRIBUTING.md are present for contribution guidance.
 - Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
 - Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
-- Spell out contributor responsibilities for tests, documentation, and review so expectations are clear for Python-focused teams.
 
 ## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json OR .github/dependabot.yml. Verify Python dependency PRs.
+- Ensure at least one of renovate.json, .renovaterc.json, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Use requirements.txt with pinned versions or poetry.lock for deterministic installs.
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'lint-imports' successfully. Config must exist in pyproject.toml [tool.importlinter] section OR .importlinter file.
+- Common tools: import-linter, pydeps. Example config files: pyproject.toml, .importlinter.
+- Consider adding pyproject.toml, .importlinter if applicable.
+- Configure [tool.importlinter] in pyproject.toml OR use standalone .importlinter file. pydeps is visualization-only.
 
 ### Integration Testing
 
 - Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm there is a separate integration or API test suite (for example, a dedicated tests/integration directory) and run it to verify interactions with databases, services, or external systems.
+- Common tools: pytest. Example config files: tests/integration/.
 - Separate integration tests from unit tests, using fixtures to handle databases, services, or other external systems.
 
 ### Performance Baselines
 
 - Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Identify and run the configured performance checks or benchmarks (for example, pytest-benchmark or cProfile-based scripts) and confirm that their results are recorded and compared over time.
+- Common tools: pytest-benchmark, cProfile. Example config files: pytest.ini, pyproject.toml.
 - Use simple benchmarks or profiling runs to characterize bottlenecks and watch for regressions in critical workflows.
 
 ### Complexity Analysis
 
 - Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run the configured complexity tool (for example, radon) on the codebase and review the report to ensure new or heavily changed functions are not excessively complex.
+- Common tools: radon. Example config files: radon.cfg.
 - Use radon or similar tools to track complexity of Python functions and keep new code within acceptable limits.
 
 ### Accessibility Auditing
 
 - Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For Python-backed web UIs, run the configured accessibility tooling (for example, pa11y or axe via a headless browser) against key routes and verify that critical issues are fixed or tracked.
+- Common tools: pa11y.
 - Use headless browser-based tools to scan Python-backed web UIs for accessibility issues on high-traffic routes.
 
 ## Optional Enhancements
@@ -120,4 +174,6 @@ This document provides high-level guidance for an autonomous coding agent to bri
 ### Observability (Logging & Error Handling)
 
 - Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that a structured logging setup (such as structlog or configured logging with JSON formatting) is in place and that critical paths log enough information to debug failures in production.
+- Common tools: structlog, loguru. Example config files: logging configuration files, pyproject.toml.
 - Use structured logging for Python services and ensure critical paths record enough context to debug issues after the fact.

--- a/instructions.python.md
+++ b/instructions.python.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: pyproject.toml (or ruff.toml / .flake8 / setup.cfg) signals that linting tools are configured for the repository.
 - Ensure at least one of pyproject.toml, ruff.toml, .flake8, setup.cfg, tox.ini is present.
-- Common tools: ruff, flake8. Example config files: pyproject.toml, .flake8, ruff.toml.
 - Bazel commands: `bazel test //...:ruff_test`, `bazel run //tools/lint:ruff -- check .`.
+- Example only; actual targets are repo-defined. Use rules_python with ruff wrapped as py_test or run target.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test framework configuration is present; tests/ directory or pytest configuration exists.
-- Common tools: pytest. Example config files: pytest.ini, pyproject.toml.
-- Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
 - Bazel commands: `bazel test //...`.
+- Example only; actual targets are repo-defined. Use rules_python py_test for pytest-based tests.
+- Common tools: pytest. Example config files: pytest.ini, pyproject.toml.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the unit tests with coverage (for example, pytest with pytest-cov) and confirm that coverage reports are generated and referenced in CI to enforce or track thresholds.
-- Common tools: pytest, pytest-cov, coverage.py. Example config files: pytest.ini, pyproject.toml.
 - Bazel commands: `bazel coverage //...`.
 - Use rules_python py_test with coverage instrumentation. Combine with --combined_report=lcov.
+- Common tools: pytest, pytest-cov, coverage.py. Example config files: pytest.ini, pyproject.toml.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking (if used), tests, and any packaging or container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Bazel py_binary and py_test targets replace traditional Python tooling.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the configured formatter (for example, `black .` or `black --check .`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
-- Common tools: black. Example config files: pyproject.toml.
 - Bazel commands: `bazel run //tools/format:black -- --check .`.
 - Wrap black as a py_binary run target for format checking.
+- Common tools: black. Example config files: pyproject.toml.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: pyproject.toml (or mypy.ini) signals that mypy configuration is available for the repository.
 - Ensure pyproject.toml exists in the repository.
-- Common tools: mypy. Example config files: mypy.ini, pyproject.toml.
-- Consider adding mypy.ini if applicable.
+- Bazel commands: `bazel test //...:mypy_test`, `bazel run //tools/typecheck:mypy`.
+- Example only; actual targets are repo-defined. Wrap mypy as a py_test or run target.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.rust.azure-devops.md
+++ b/instructions.rust.azure-devops.md
@@ -1,0 +1,178 @@
+# Repository Standards Instructions
+
+> Auto-generated from `config/standards.rust.azure-devops.json`
+> Stack: Rust | CI: azure-devops
+
+This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
+
+## Core Requirements
+
+### Git and Docker Ignore Files
+
+- Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
+- Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
+- Consider adding .dockerignore if applicable.
+
+### Linting
+
+- Run static code linting to enforce consistency and catch common issues early.
+- Verify with: Clippy is available via rustup component. Run 'cargo clippy' to verify linting is configured.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: clippy, cargo-clippy. Example config files: clippy.toml, .clippy.toml.
+- Consider adding clippy.toml, .clippy.toml if applicable.
+
+### Unit Test Runner
+
+- Provide a deterministic unit test framework with a single command to run all tests.
+- Verify with: Run 'cargo test' to verify the test suite is configured and passing.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: cargo test. Example config files: Cargo.toml.
+- Consider adding tests/ if applicable.
+
+### Containerization (Docker / Docker Compose)
+
+- Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
+- Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
+- Consider adding docker-compose.yml if applicable.
+
+### Semantic Versioning
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Verify with: Check that Cargo.toml version follows SemVer and verify changelog generation from commit history.
+- Common tools: cargo-release, semantic-release. Example config files: Cargo.toml, CHANGELOG.md.
+
+### Commit Linting
+
+- Enforce structured commit messages such as Conventional Commits.
+- Verify with: Test that non-conforming commit messages are rejected by the configured hooks or CI check.
+- Common tools: commitlint, commitizen. Example config files: commitlint.config.js, .cz.toml.
+- Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.
+
+### Unit Test Reporter / Coverage
+
+- Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
+- Verify with: Run 'cargo tarpaulin' or equivalent and verify coverage reports are generated and thresholds enforced.
+- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
+- Bazel commands: `bazel coverage //...`.
+- Bazel coverage with rules_rust requires LLVM instrumentation. May need additional toolchain configuration.
+
+### CI Quality Gates
+
+- Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
+- Verify with: Verify CI runs cargo clippy, cargo test, and cargo build before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- rules_rust provides rust_library, rust_test, and clippy_aspect for complete CI.
+
+### Code Formatter
+
+- Automatic code formatting to maintain a consistent style across all contributors.
+- Verify with: Run 'cargo fmt --check' and confirm it reports clean formatting. Use 'cargo fmt' to auto-fix.
+- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
+- Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=rustfmt_checks`.
+- rules_rust includes rustfmt_aspect for Bazel-native format checking.
+
+### Pre-Commit Hooks
+
+- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect .pre-commit-config.yaml and confirm that hooks run cargo fmt --check and cargo clippy before commits.
+- Common tools: pre-commit, cargo-husky. Example config files: .pre-commit-config.yaml.
+- Use pre-commit with rust hooks for cargo fmt and cargo clippy on staged files. cargo-husky is an alternative.
+
+### Type Checking
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: Run 'cargo check' or 'cargo build' to verify type correctness. All Rust code is type-checked by default.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: rustc (built-in). Example config files: Cargo.toml.
+- Bazel commands: `bazel build //...`.
+
+### Dependency Management & Vulnerability Scanning
+
+- Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: Cargo.lock is present; run 'cargo audit' or 'cargo deny check' to verify security scanning.
+- Ensure at least one of Cargo.lock is present.
+- Common tools: cargo-audit, cargo-deny. Example config files: Cargo.lock, deny.toml.
+- Required for binaries/services; optional for libraries (add to .gitignore for libs). See https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: rust-toolchain.toml or rust-toolchain file specifies the required Rust version.
+- Example config files: rust-toolchain.toml, rust-toolchain.
+- Consider adding rust-toolchain.toml, rust-toolchain if applicable.
+
+### Documentation Standards
+
+- Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present; run 'cargo doc' to generate API docs.
+- Ensure README.md exists in the repository.
+- Common tools: rustdoc, mdBook. Example config files: README.md, docs/.
+- Consider adding docs/, book.toml if applicable.
+
+### Repository Governance
+
+- Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present; CODE_OF_CONDUCT.md and CONTRIBUTING.md provide contribution guidance.
+- Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
+- Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
+
+## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json OR .github/dependabot.yml. Verify Cargo dependency PRs.
+- Ensure at least one of renovate.json, .renovaterc.json, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Both support Cargo.toml/Cargo.lock. Works with cargo workspaces. Security scanning is covered by dependency-security (cargo-audit/cargo-deny).
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'cargo deny check bans' to verify dependency constraints.
+- Common tools: cargo-deny. Example config files: deny.toml.
+- Consider adding deny.toml if applicable.
+- cargo-deny's [bans] section enforces dependency graph rules (deny specific crates, wildcards). Extend existing config if using for security scanning.
+
+### Integration Testing
+
+- Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm tests/ directory contains integration tests and run 'cargo test' to verify cross-component flows.
+- Common tools: cargo test. Example config files: tests/.
+- Use the tests/ directory for integration tests. Use #[ignore] attribute for slow tests and run with 'cargo test -- --ignored'.
+
+### Performance Baselines
+
+- Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Run 'cargo bench' and verify benchmark results are captured and compared against baselines.
+- Common tools: criterion, cargo bench. Example config files: benches/.
+- Use criterion for statistical benchmarking. Create benches/ directory for benchmark files. Track results over time in CI.
+
+### Complexity Analysis
+
+- Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run 'cargo clippy' and review complexity-related warnings. Ensure new code stays within acceptable limits.
+- Common tools: clippy, cargo-geiger. Example config files: clippy.toml.
+- Clippy includes cognitive complexity warnings. Use cargo-geiger for unsafe code metrics. Configure thresholds in clippy.toml.
+
+### Accessibility Auditing
+
+- Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For web-facing Rust apps, run accessibility audits against key routes using axe or pa11y.
+- Common tools: axe-core, pa11y.
+- For Rust web frameworks (Actix, Axum, Rocket), use headless browser-based accessibility tools to audit rendered HTML.
+
+## Optional Enhancements
+
+### Observability (Logging & Error Handling)
+
+- Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that tracing or log crate is configured with appropriate subscriber/logger and emits structured output.
+- Common tools: tracing, log.
+- Use the tracing crate for structured logging with spans and events. Configure tracing-subscriber for output formatting.

--- a/instructions.rust.azure-devops.md
+++ b/instructions.rust.azure-devops.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: Clippy is available via rustup component. Run 'cargo clippy' to verify linting is configured.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: clippy, cargo-clippy. Example config files: clippy.toml, .clippy.toml.
-- Consider adding clippy.toml, .clippy.toml if applicable.
+- Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%clippy_aspect --output_groups=clippy_checks`.
+- Example only; actual targets are repo-defined. rules_rust includes clippy_aspect for Bazel-native Clippy linting.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Run 'cargo test' to verify the test suite is configured and passing.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: cargo test. Example config files: Cargo.toml.
-- Consider adding tests/ if applicable.
+- Bazel commands: `bazel test //...`.
+- rules_rust rust_test targets run cargo test under Bazel's hermetic environment.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run 'cargo tarpaulin' or equivalent and verify coverage reports are generated and thresholds enforced.
-- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
 - Bazel commands: `bazel coverage //...`.
 - Bazel coverage with rules_rust requires LLVM instrumentation. May need additional toolchain configuration.
+- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Verify CI runs cargo clippy, cargo test, and cargo build before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - rules_rust provides rust_library, rust_test, and clippy_aspect for complete CI.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run 'cargo fmt --check' and confirm it reports clean formatting. Use 'cargo fmt' to auto-fix.
-- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
 - Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=rustfmt_checks`.
 - rules_rust includes rustfmt_aspect for Bazel-native format checking.
+- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: Run 'cargo check' or 'cargo build' to verify type correctness. All Rust code is type-checked by default.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: rustc (built-in). Example config files: Cargo.toml.
 - Bazel commands: `bazel build //...`.
+- Rust type checking is inherent to compilation. bazel build with rules_rust enforces type safety.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.rust.github-actions.md
+++ b/instructions.rust.github-actions.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: Clippy is available via rustup component. Run 'cargo clippy' to verify linting is configured.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: clippy, cargo-clippy. Example config files: clippy.toml, .clippy.toml.
-- Consider adding clippy.toml, .clippy.toml if applicable.
+- Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%clippy_aspect --output_groups=clippy_checks`.
+- Example only; actual targets are repo-defined. rules_rust includes clippy_aspect for Bazel-native Clippy linting.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Run 'cargo test' to verify the test suite is configured and passing.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: cargo test. Example config files: Cargo.toml.
-- Consider adding tests/ if applicable.
+- Bazel commands: `bazel test //...`.
+- rules_rust rust_test targets run cargo test under Bazel's hermetic environment.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run 'cargo tarpaulin' or equivalent and verify coverage reports are generated and thresholds enforced.
-- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
 - Bazel commands: `bazel coverage //...`.
 - Bazel coverage with rules_rust requires LLVM instrumentation. May need additional toolchain configuration.
+- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Verify CI runs cargo clippy, cargo test, and cargo build before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - rules_rust provides rust_library, rust_test, and clippy_aspect for complete CI.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run 'cargo fmt --check' and confirm it reports clean formatting. Use 'cargo fmt' to auto-fix.
-- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
 - Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=rustfmt_checks`.
 - rules_rust includes rustfmt_aspect for Bazel-native format checking.
+- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: Run 'cargo check' or 'cargo build' to verify type correctness. All Rust code is type-checked by default.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: rustc (built-in). Example config files: Cargo.toml.
 - Bazel commands: `bazel build //...`.
+- Rust type checking is inherent to compilation. bazel build with rules_rust enforces type safety.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.rust.github-actions.md
+++ b/instructions.rust.github-actions.md
@@ -1,0 +1,178 @@
+# Repository Standards Instructions
+
+> Auto-generated from `config/standards.rust.github-actions.json`
+> Stack: Rust | CI: github-actions
+
+This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
+
+## Core Requirements
+
+### Git and Docker Ignore Files
+
+- Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
+- Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
+- Consider adding .dockerignore if applicable.
+
+### Linting
+
+- Run static code linting to enforce consistency and catch common issues early.
+- Verify with: Clippy is available via rustup component. Run 'cargo clippy' to verify linting is configured.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: clippy, cargo-clippy. Example config files: clippy.toml, .clippy.toml.
+- Consider adding clippy.toml, .clippy.toml if applicable.
+
+### Unit Test Runner
+
+- Provide a deterministic unit test framework with a single command to run all tests.
+- Verify with: Run 'cargo test' to verify the test suite is configured and passing.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: cargo test. Example config files: Cargo.toml.
+- Consider adding tests/ if applicable.
+
+### Containerization (Docker / Docker Compose)
+
+- Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
+- Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
+- Consider adding docker-compose.yml if applicable.
+
+### Semantic Versioning
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Verify with: Check that Cargo.toml version follows SemVer and verify changelog generation from commit history.
+- Common tools: cargo-release, semantic-release. Example config files: Cargo.toml, CHANGELOG.md.
+
+### Commit Linting
+
+- Enforce structured commit messages such as Conventional Commits.
+- Verify with: Test that non-conforming commit messages are rejected by the configured hooks or CI check.
+- Common tools: commitlint, commitizen. Example config files: commitlint.config.js, .cz.toml.
+- Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.
+
+### Unit Test Reporter / Coverage
+
+- Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
+- Verify with: Run 'cargo tarpaulin' or equivalent and verify coverage reports are generated and thresholds enforced.
+- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
+- Bazel commands: `bazel coverage //...`.
+- Bazel coverage with rules_rust requires LLVM instrumentation. May need additional toolchain configuration.
+
+### CI Quality Gates
+
+- Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
+- Verify with: Verify CI runs cargo clippy, cargo test, and cargo build before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- rules_rust provides rust_library, rust_test, and clippy_aspect for complete CI.
+
+### Code Formatter
+
+- Automatic code formatting to maintain a consistent style across all contributors.
+- Verify with: Run 'cargo fmt --check' and confirm it reports clean formatting. Use 'cargo fmt' to auto-fix.
+- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
+- Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=rustfmt_checks`.
+- rules_rust includes rustfmt_aspect for Bazel-native format checking.
+
+### Pre-Commit Hooks
+
+- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect .pre-commit-config.yaml and confirm that hooks run cargo fmt --check and cargo clippy before commits.
+- Common tools: pre-commit, cargo-husky. Example config files: .pre-commit-config.yaml.
+- Use pre-commit with rust hooks for cargo fmt and cargo clippy on staged files. cargo-husky is an alternative.
+
+### Type Checking
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: Run 'cargo check' or 'cargo build' to verify type correctness. All Rust code is type-checked by default.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: rustc (built-in). Example config files: Cargo.toml.
+- Bazel commands: `bazel build //...`.
+
+### Dependency Management & Vulnerability Scanning
+
+- Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: Cargo.lock is present; run 'cargo audit' or 'cargo deny check' to verify security scanning.
+- Ensure at least one of Cargo.lock is present.
+- Common tools: cargo-audit, cargo-deny. Example config files: Cargo.lock, deny.toml.
+- Required for binaries/services; optional for libraries (add to .gitignore for libs). See https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: rust-toolchain.toml or rust-toolchain file specifies the required Rust version.
+- Example config files: rust-toolchain.toml, rust-toolchain.
+- Consider adding rust-toolchain.toml, rust-toolchain if applicable.
+
+### Documentation Standards
+
+- Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present; run 'cargo doc' to generate API docs.
+- Ensure README.md exists in the repository.
+- Common tools: rustdoc, mdBook. Example config files: README.md, docs/.
+- Consider adding docs/, book.toml if applicable.
+
+### Repository Governance
+
+- Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present; CODE_OF_CONDUCT.md and CONTRIBUTING.md provide contribution guidance.
+- Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
+- Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
+
+## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json OR .github/dependabot.yml. Verify Cargo dependency PRs.
+- Ensure at least one of renovate.json, .renovaterc.json, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Both support Cargo.toml/Cargo.lock. Works with cargo workspaces. Security scanning is covered by dependency-security (cargo-audit/cargo-deny).
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'cargo deny check bans' to verify dependency constraints.
+- Common tools: cargo-deny. Example config files: deny.toml.
+- Consider adding deny.toml if applicable.
+- cargo-deny's [bans] section enforces dependency graph rules (deny specific crates, wildcards). Extend existing config if using for security scanning.
+
+### Integration Testing
+
+- Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm tests/ directory contains integration tests and run 'cargo test' to verify cross-component flows.
+- Common tools: cargo test. Example config files: tests/.
+- Use the tests/ directory for integration tests. Use #[ignore] attribute for slow tests and run with 'cargo test -- --ignored'.
+
+### Performance Baselines
+
+- Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Run 'cargo bench' and verify benchmark results are captured and compared against baselines.
+- Common tools: criterion, cargo bench. Example config files: benches/.
+- Use criterion for statistical benchmarking. Create benches/ directory for benchmark files. Track results over time in CI.
+
+### Complexity Analysis
+
+- Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run 'cargo clippy' and review complexity-related warnings. Ensure new code stays within acceptable limits.
+- Common tools: clippy, cargo-geiger. Example config files: clippy.toml.
+- Clippy includes cognitive complexity warnings. Use cargo-geiger for unsafe code metrics. Configure thresholds in clippy.toml.
+
+### Accessibility Auditing
+
+- Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For web-facing Rust apps, run accessibility audits against key routes using axe or pa11y.
+- Common tools: axe-core, pa11y.
+- For Rust web frameworks (Actix, Axum, Rocket), use headless browser-based accessibility tools to audit rendered HTML.
+
+## Optional Enhancements
+
+### Observability (Logging & Error Handling)
+
+- Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that tracing or log crate is configured with appropriate subscriber/logger and emits structured output.
+- Common tools: tracing, log.
+- Use the tracing crate for structured logging with spans and events. Configure tracing-subscriber for output formatting.

--- a/instructions.rust.md
+++ b/instructions.rust.md
@@ -20,16 +20,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Run static code linting to enforce consistency and catch common issues early.
 - Verify with: Clippy is available via rustup component. Run 'cargo clippy' to verify linting is configured.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: clippy, cargo-clippy. Example config files: clippy.toml, .clippy.toml.
-- Consider adding clippy.toml, .clippy.toml if applicable.
+- Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%clippy_aspect --output_groups=clippy_checks`.
+- Example only; actual targets are repo-defined. rules_rust includes clippy_aspect for Bazel-native Clippy linting.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Run 'cargo test' to verify the test suite is configured and passing.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: cargo test. Example config files: Cargo.toml.
-- Consider adding tests/ if applicable.
+- Bazel commands: `bazel test //...`.
+- rules_rust rust_test targets run cargo test under Bazel's hermetic environment.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run 'cargo tarpaulin' or equivalent and verify coverage reports are generated and thresholds enforced.
-- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
 - Bazel commands: `bazel coverage //...`.
 - Bazel coverage with rules_rust requires LLVM instrumentation. May need additional toolchain configuration.
+- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Verify CI runs cargo clippy, cargo test, and cargo build before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - rules_rust provides rust_library, rust_test, and clippy_aspect for complete CI.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run 'cargo fmt --check' and confirm it reports clean formatting. Use 'cargo fmt' to auto-fix.
-- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
 - Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=rustfmt_checks`.
 - rules_rust includes rustfmt_aspect for Bazel-native format checking.
+- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
 
 ### Pre-Commit Hooks
 
@@ -88,8 +88,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
 - Verify with: Run 'cargo check' or 'cargo build' to verify type correctness. All Rust code is type-checked by default.
 - Ensure Cargo.toml exists in the repository.
-- Common tools: rustc (built-in). Example config files: Cargo.toml.
 - Bazel commands: `bazel build //...`.
+- Rust type checking is inherent to compilation. bazel build with rules_rust enforces type safety.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.rust.md
+++ b/instructions.rust.md
@@ -1,0 +1,178 @@
+# Repository Standards Instructions
+
+> Auto-generated from `config/standards.rust.json`
+> Stack: Rust | CI: azure-devops, github-actions
+
+This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
+
+## Core Requirements
+
+### Git and Docker Ignore Files
+
+- Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
+- Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
+- Consider adding .dockerignore if applicable.
+
+### Linting
+
+- Run static code linting to enforce consistency and catch common issues early.
+- Verify with: Clippy is available via rustup component. Run 'cargo clippy' to verify linting is configured.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: clippy, cargo-clippy. Example config files: clippy.toml, .clippy.toml.
+- Consider adding clippy.toml, .clippy.toml if applicable.
+
+### Unit Test Runner
+
+- Provide a deterministic unit test framework with a single command to run all tests.
+- Verify with: Run 'cargo test' to verify the test suite is configured and passing.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: cargo test. Example config files: Cargo.toml.
+- Consider adding tests/ if applicable.
+
+### Containerization (Docker / Docker Compose)
+
+- Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
+- Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
+- Consider adding docker-compose.yml if applicable.
+
+### Semantic Versioning
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Verify with: Check that Cargo.toml version follows SemVer and verify changelog generation from commit history.
+- Common tools: cargo-release, semantic-release. Example config files: Cargo.toml, CHANGELOG.md.
+
+### Commit Linting
+
+- Enforce structured commit messages such as Conventional Commits.
+- Verify with: Test that non-conforming commit messages are rejected by the configured hooks or CI check.
+- Common tools: commitlint, commitizen. Example config files: commitlint.config.js, .cz.toml.
+- Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.
+
+### Unit Test Reporter / Coverage
+
+- Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
+- Verify with: Run 'cargo tarpaulin' or equivalent and verify coverage reports are generated and thresholds enforced.
+- Common tools: cargo-tarpaulin, llvm-cov, grcov. Example config files: Cargo.toml.
+- Bazel commands: `bazel coverage //...`.
+- Bazel coverage with rules_rust requires LLVM instrumentation. May need additional toolchain configuration.
+
+### CI Quality Gates
+
+- Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
+- Verify with: Verify CI runs cargo clippy, cargo test, and cargo build before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- rules_rust provides rust_library, rust_test, and clippy_aspect for complete CI.
+
+### Code Formatter
+
+- Automatic code formatting to maintain a consistent style across all contributors.
+- Verify with: Run 'cargo fmt --check' and confirm it reports clean formatting. Use 'cargo fmt' to auto-fix.
+- Common tools: rustfmt. Example config files: rustfmt.toml, .rustfmt.toml.
+- Bazel commands: `bazel build //... --aspects=@rules_rust//rust:defs.bzl%rustfmt_aspect --output_groups=rustfmt_checks`.
+- rules_rust includes rustfmt_aspect for Bazel-native format checking.
+
+### Pre-Commit Hooks
+
+- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect .pre-commit-config.yaml and confirm that hooks run cargo fmt --check and cargo clippy before commits.
+- Common tools: pre-commit, cargo-husky. Example config files: .pre-commit-config.yaml.
+- Use pre-commit with rust hooks for cargo fmt and cargo clippy on staged files. cargo-husky is an alternative.
+
+### Type Checking
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: Run 'cargo check' or 'cargo build' to verify type correctness. All Rust code is type-checked by default.
+- Ensure Cargo.toml exists in the repository.
+- Common tools: rustc (built-in). Example config files: Cargo.toml.
+- Bazel commands: `bazel build //...`.
+
+### Dependency Management & Vulnerability Scanning
+
+- Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: Cargo.lock is present; run 'cargo audit' or 'cargo deny check' to verify security scanning.
+- Ensure at least one of Cargo.lock is present.
+- Common tools: cargo-audit, cargo-deny. Example config files: Cargo.lock, deny.toml.
+- Required for binaries/services; optional for libraries (add to .gitignore for libs). See https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control
+
+### Runtime Version Specification
+
+- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: rust-toolchain.toml or rust-toolchain file specifies the required Rust version.
+- Example config files: rust-toolchain.toml, rust-toolchain.
+- Consider adding rust-toolchain.toml, rust-toolchain if applicable.
+
+### Documentation Standards
+
+- Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present; run 'cargo doc' to generate API docs.
+- Ensure README.md exists in the repository.
+- Common tools: rustdoc, mdBook. Example config files: README.md, docs/.
+- Consider adding docs/, book.toml if applicable.
+
+### Repository Governance
+
+- Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present; CODE_OF_CONDUCT.md and CONTRIBUTING.md provide contribution guidance.
+- Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
+- Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
+
+## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json OR .github/dependabot.yml. Verify Cargo dependency PRs.
+- Ensure at least one of renovate.json, .renovaterc.json, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Both support Cargo.toml/Cargo.lock. Works with cargo workspaces. Security scanning is covered by dependency-security (cargo-audit/cargo-deny).
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'cargo deny check bans' to verify dependency constraints.
+- Common tools: cargo-deny. Example config files: deny.toml.
+- Consider adding deny.toml if applicable.
+- cargo-deny's [bans] section enforces dependency graph rules (deny specific crates, wildcards). Extend existing config if using for security scanning.
+
+### Integration Testing
+
+- Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm tests/ directory contains integration tests and run 'cargo test' to verify cross-component flows.
+- Common tools: cargo test. Example config files: tests/.
+- Use the tests/ directory for integration tests. Use #[ignore] attribute for slow tests and run with 'cargo test -- --ignored'.
+
+### Performance Baselines
+
+- Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Run 'cargo bench' and verify benchmark results are captured and compared against baselines.
+- Common tools: criterion, cargo bench. Example config files: benches/.
+- Use criterion for statistical benchmarking. Create benches/ directory for benchmark files. Track results over time in CI.
+
+### Complexity Analysis
+
+- Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run 'cargo clippy' and review complexity-related warnings. Ensure new code stays within acceptable limits.
+- Common tools: clippy, cargo-geiger. Example config files: clippy.toml.
+- Clippy includes cognitive complexity warnings. Use cargo-geiger for unsafe code metrics. Configure thresholds in clippy.toml.
+
+### Accessibility Auditing
+
+- Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For web-facing Rust apps, run accessibility audits against key routes using axe or pa11y.
+- Common tools: axe-core, pa11y.
+- For Rust web frameworks (Actix, Axum, Rocket), use headless browser-based accessibility tools to audit rendered HTML.
+
+## Optional Enhancements
+
+### Observability (Logging & Error Handling)
+
+- Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that tracing or log crate is configured with appropriate subscriber/logger and emits structured output.
+- Common tools: tracing, log.
+- Use the tracing crate for structured logging with spans and events. Configure tracing-subscriber for output formatting.

--- a/instructions.typescript-js.azure-devops.md
+++ b/instructions.typescript-js.azure-devops.md
@@ -21,15 +21,15 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of eslint.config.js (or any .eslintrc\* file) indicates linting is enforced for the repository.
 - Ensure at least one of eslint.config.js, eslint.config.mjs, eslint.config.cjs, .eslintrc.js, .eslintrc.cjs, .eslintrc.json, .eslintrc.yaml, .eslintrc.yml is present.
 - Define a `lint` script or equivalent command.
-- Common tools: eslint. Example config files: .eslintrc.\*, eslint.config.js.
+- Bazel commands: `bazel test //... --aspects=//tools:lint.bzl%eslint_aspect --output_groups=report`.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test framework configuration is present; test script is defined in package.json.
 - Define a `test` script or equivalent command.
-- Common tools: jest. Example config files: jest.config.\*.
-- Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
+- Bazel commands: `bazel test //...`.
+- Bazel discovers and runs all test targets. Use rules_js for Jest/Vitest integration.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the unit tests with coverage enabled and confirm that a coverage report is produced and that the configured threshold (around 80%) is enforced for new changes.
-- Common tools: jest, nyc. Example config files: jest.config.\*.
 - Bazel commands: `bazel coverage //...`.
 - Bazel coverage collects coverage data from all test targets. Use --combined_report=lcov for aggregated reports.
+- Common tools: jest, nyc. Example config files: jest.config.\*.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking, tests, build, and any required container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Replace npm run ci with Bazel commands. All quality gates run as Bazel targets.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the formatter in check mode (for example, `npm run format:check`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
-- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 - Bazel commands: `bazel run //tools/format:check`, `bazel test //...:format_test`.
 - Wrap Prettier as a run target for formatting checks. Use aspect_rules_lint for format aspects.
+- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 
 ### Pre-Commit Hooks
 
@@ -89,7 +89,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of tsconfig.json indicates type-checking is configured for the repository.
 - Ensure tsconfig.json exists in the repository.
 - Define a `typecheck` script or equivalent command.
-- Common tools: TypeScript compiler (tsc). Example config files: tsconfig.json.
+- Bazel commands: `bazel build //...`.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.typescript-js.azure-devops.md
+++ b/instructions.typescript-js.azure-devops.md
@@ -1,7 +1,7 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config/standards.typescript-js.github-actions.json`
-> Stack: TypeScript / JavaScript | CI: github-actions
+> Auto-generated from `config/standards.typescript-js.azure-devops.json`
+> Stack: TypeScript / JavaScript | CI: azure-devops
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
 

--- a/instructions.typescript-js.github-actions.md
+++ b/instructions.typescript-js.github-actions.md
@@ -21,15 +21,15 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of eslint.config.js (or any .eslintrc\* file) indicates linting is enforced for the repository.
 - Ensure at least one of eslint.config.js, eslint.config.mjs, eslint.config.cjs, .eslintrc.js, .eslintrc.cjs, .eslintrc.json, .eslintrc.yaml, .eslintrc.yml is present.
 - Define a `lint` script or equivalent command.
-- Common tools: eslint. Example config files: .eslintrc.\*, eslint.config.js.
+- Bazel commands: `bazel test //... --aspects=//tools:lint.bzl%eslint_aspect --output_groups=report`.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test framework configuration is present; test script is defined in package.json.
 - Define a `test` script or equivalent command.
-- Common tools: jest. Example config files: jest.config.\*.
-- Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
+- Bazel commands: `bazel test //...`.
+- Bazel discovers and runs all test targets. Use rules_js for Jest/Vitest integration.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the unit tests with coverage enabled and confirm that a coverage report is produced and that the configured threshold (around 80%) is enforced for new changes.
-- Common tools: jest, nyc. Example config files: jest.config.\*.
 - Bazel commands: `bazel coverage //...`.
 - Bazel coverage collects coverage data from all test targets. Use --combined_report=lcov for aggregated reports.
+- Common tools: jest, nyc. Example config files: jest.config.\*.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking, tests, build, and any required container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Replace npm run ci with Bazel commands. All quality gates run as Bazel targets.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the formatter in check mode (for example, `npm run format:check`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
-- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 - Bazel commands: `bazel run //tools/format:check`, `bazel test //...:format_test`.
 - Wrap Prettier as a run target for formatting checks. Use aspect_rules_lint for format aspects.
+- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 
 ### Pre-Commit Hooks
 
@@ -89,7 +89,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of tsconfig.json indicates type-checking is configured for the repository.
 - Ensure tsconfig.json exists in the repository.
 - Define a `typecheck` script or equivalent command.
-- Common tools: TypeScript compiler (tsc). Example config files: tsconfig.json.
+- Bazel commands: `bazel build //...`.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.typescript-js.github-actions.md
+++ b/instructions.typescript-js.github-actions.md
@@ -1,6 +1,6 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config\standards.typescript-js.github-actions.json`
+> Auto-generated from `config/standards.typescript-js.github-actions.json`
 > Stack: TypeScript / JavaScript | CI: github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
@@ -10,112 +10,162 @@ This document provides high-level guidance for an autonomous coding agent to bri
 ### Git and Docker Ignore Files
 
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
+- Verify with: .gitignore must exist; .dockerignore is recommended when containerizing or using Docker workflows.
 - Ensure .gitignore exists in the repository.
+- Example config files: .gitignore, .dockerignore.
 - Consider adding .dockerignore if applicable.
 
 ### Linting
 
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure eslint.config.js exists in the repository.
-- Consider adding .eslintrc.js, .eslintrc.cjs, .eslintrc.json and others if applicable.
+- Verify with: Presence of eslint.config.js (or any .eslintrc\* file) indicates linting is enforced for the repository.
+- Ensure at least one of eslint.config.js, eslint.config.mjs, eslint.config.cjs, .eslintrc.js, .eslintrc.cjs, .eslintrc.json, .eslintrc.yaml, .eslintrc.yml is present.
 - Define a `lint` script or equivalent command.
-- Treat new lint errors as CI failures; keep existing issues as warnings until addressed.
+- Common tools: eslint. Example config files: .eslintrc.\*, eslint.config.js.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
-- Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
+- Verify with: Test framework configuration is present; test script is defined in package.json.
 - Define a `test` script or equivalent command.
-- Keep unit tests fast and deterministic; move slow or flaky tests into integration or E2E suites.
+- Common tools: jest. Example config files: jest.config.\*.
+- Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
 
 ### Containerization (Docker / Docker Compose)
 
 - Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
+- Verify with: Dockerfile must be present; docker-compose.yml is optional and indicates orchestration usage.
 - Ensure Dockerfile exists in the repository.
+- Example config files: Dockerfile, docker-compose.yml.
 - Consider adding docker-compose.yml if applicable.
-- Use multi-stage builds and pin Node.js and base image versions in the Dockerfile to match CI (e.g., node:22-alpine).
 
 ### Semantic Versioning
 
 - Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+- Verify with: Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries.
+- Common tools: semantic-release, standard-version. Example config files: .releaserc, package.json, CHANGELOG.md.
 
 ### Commit Linting
 
 - Enforce structured commit messages such as Conventional Commits.
+- Verify with: Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen).
+- Common tools: @commitlint/cli, @commitlint/config-conventional. Example config files: commitlint.config.\*.
 - Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.
 
 ### Unit Test Reporter / Coverage
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
-- Collect coverage in lcov or similar format; use diff coverage so legacy gaps are visible but non-blocking.
+- Verify with: Run the unit tests with coverage enabled and confirm that a coverage report is produced and that the configured threshold (around 80%) is enforced for new changes.
+- Common tools: jest, nyc. Example config files: jest.config.\*.
+- Bazel commands: `bazel coverage //...`.
+- Bazel coverage collects coverage data from all test targets. Use --combined_report=lcov for aggregated reports.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
-- Expose a single npm script (e.g., `npm run ci`) that mirrors the CI pipeline so contributors can reproduce failures locally.
+- Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking, tests, build, and any required container checks before merging to main.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
+- Bazel commands: `bazel build //...`, `bazel test //...`.
+- Replace npm run ci with Bazel commands. All quality gates run as Bazel targets.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
-- Run Prettier in check mode in CI; auto-fix locally via pre-commit hooks or editor integration.
+- Verify with: Run the formatter in check mode (for example, `npm run format:check`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
+- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
+- Bazel commands: `bazel run //tools/format:check`, `bazel test //...:format_test`.
+- Wrap Prettier as a run target for formatting checks. Use aspect_rules_lint for format aspects.
 
 ### Pre-Commit Hooks
 
 - Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
+- Verify with: Inspect the pre-commit and commit-msg hooks (for example, files under .husky or other hook tooling) and confirm they run linting/formatting and commit linting on staged changes.
+- Common tools: husky, lint-staged. Example config files: .husky/, package.json.
 - Run ESLint and Prettier on staged files and enforce commit message format via commit-msg hooks.
 
 ### Type Checking
 
 - Use static type checking to catch errors before runtime and enforce strictness on new code.
+- Verify with: Presence of tsconfig.json indicates type-checking is configured for the repository.
 - Ensure tsconfig.json exists in the repository.
 - Define a `typecheck` script or equivalent command.
-- Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.
+- Common tools: TypeScript compiler (tsc). Example config files: tsconfig.json.
 
 ### Dependency Management & Vulnerability Scanning
 
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
+- Verify with: Dependency lockfile is present; security scanning is configured in CI or project tooling.
+- Common tools: npm audit, Snyk. Example config files: package-lock.json, pnpm-lock.yaml, yarn.lock.
 - Consider adding package-lock.json, pnpm-lock.yaml, yarn.lock if applicable.
 - Require a lockfile for reproducible installs and pin Node.js/tooling versions; block merges on new high-severity vulnerabilities.
 
 ### Runtime Version Specification
 
 - Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+- Verify with: package.json must contain an 'engines' field specifying the required Node.js version.
 - Ensure package.json exists in the repository.
+- Example config files: package.json.
 
 ### Documentation Standards
 
 - Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
+- Verify with: README.md is present in the repository root; docs/ directory or documentation tooling configuration exists if applicable.
 - Ensure README.md exists in the repository.
+- Common tools: JSDoc, TypeDoc. Example config files: README.md, docs/.
 - Consider adding docs/, typedoc.json if applicable.
-- README should describe setup, scripts, and architecture; generate API docs from TypeScript types and JSDoc where helpful.
 
 ### Repository Governance
 
 - Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
+- Verify with: LICENSE file is present in the repository root; CODE_OF_CONDUCT.md and CONTRIBUTING.md are present for contribution guidance.
 - Ensure LICENSE exists in the repository.
+- Example config files: LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md.
 - Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
-- Use an SPDX license identifier in package.json and describe review expectations, tests, and docs requirements in CONTRIBUTING.md.
 
 ## Recommended Practices
+
+### Dependency Update Automation
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Verify with: Check for renovate.json (or .renovaterc.json) OR .github/dependabot.yml. Verify dependency update PRs are being created.
+- Ensure at least one of renovate.json, .renovaterc.json, renovate.json5, .renovaterc.json5, .github/dependabot.yml is present.
+- Common tools: renovate, dependabot. Example config files: renovate.json, .github/dependabot.yml.
+- Pin Renovate Docker image version in AzDO pipelines for determinism.
+
+### Dependency Architecture Rules
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Verify with: Run 'npx depcruise --validate' or equivalent. Verify architectural rules are documented and enforced.
+- Ensure at least one of .dependency-cruiser.cjs, .dependency-cruiser.js, dependency-cruiser.config.cjs, .dependency-cruiser.mjs is present.
+- Common tools: dependency-cruiser. Example config files: .dependency-cruiser.cjs, .dependency-cruiser.js, dependency-cruiser.config.cjs.
+- Pin dependency-cruiser version in package.json devDependencies.
 
 ### Integration Testing
 
 - Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
+- Verify with: Confirm there is a separate integration or end-to-end test command or configuration and run it to verify that cross-component flows behave as expected.
+- Common tools: Jest, Supertest, Playwright. Example config files: jest.config._, playwright.config._.
 - Use Supertest for HTTP APIs and Playwright or similar tools for end-to-end flows; keep integration suites slower but reliable.
 
 ### Performance Baselines
 
 - Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
+- Verify with: Identify and run the configured performance or Lighthouse-style checks and verify that key metrics are captured and compared to documented baselines.
+- Common tools: Lighthouse CI, custom Node.js benchmarks. Example config files: lighthouserc.json.
 - Run Lighthouse CI for web apps and basic Node benchmarks on critical endpoints; schedule runs or limit to key branches to keep CI fast.
 
 ### Complexity Analysis
 
 - Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
+- Verify with: Run the configured complexity tooling or rules (for example, ESLint complexity rules or Sonar analysis) and review any hot spots, ensuring new code does not exceed agreed thresholds.
+- Common tools: ESLint complexity rules, SonarQube. Example config files: .eslintrc.\*, sonar-project.properties.
 - Warn on overly complex functions and methods; fail CI only when new or modified code exceeds thresholds.
 
 ### Accessibility Auditing
 
 - Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
+- Verify with: For web-facing apps, run the configured accessibility tooling (for example, axe, pa11y, or Lighthouse accessibility audits) against key pages and confirm that critical issues are resolved.
+- Common tools: axe-core, Lighthouse accessibility audits.
 - Run accessibility checks against key pages or components in CI; fail on critical violations while treating minor issues as warnings initially.
 
 ## Optional Enhancements
@@ -123,4 +173,6 @@ This document provides high-level guidance for an autonomous coding agent to bri
 ### Observability (Logging & Error Handling)
 
 - Standardize error handling and structured logging to make debugging and production monitoring easier.
+- Verify with: Confirm that a structured logging library (such as Winston or Pino) is configured to emit JSON or key-value logs and that error handling routes important failures through this logger.
+- Common tools: Winston, Pino.
 - Adopt structured JSON logging with correlation IDs and send logs to a centralized sink in production.

--- a/instructions.typescript-js.md
+++ b/instructions.typescript-js.md
@@ -21,15 +21,15 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of eslint.config.js (or any .eslintrc\* file) indicates linting is enforced for the repository.
 - Ensure at least one of eslint.config.js, eslint.config.mjs, eslint.config.cjs, .eslintrc.js, .eslintrc.cjs, .eslintrc.json, .eslintrc.yaml, .eslintrc.yml is present.
 - Define a `lint` script or equivalent command.
-- Common tools: eslint. Example config files: .eslintrc.\*, eslint.config.js.
+- Bazel commands: `bazel test //... --aspects=//tools:lint.bzl%eslint_aspect --output_groups=report`.
 
 ### Unit Test Runner
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Verify with: Test framework configuration is present; test script is defined in package.json.
 - Define a `test` script or equivalent command.
-- Common tools: jest. Example config files: jest.config.\*.
-- Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
+- Bazel commands: `bazel test //...`.
+- Bazel discovers and runs all test targets. Use rules_js for Jest/Vitest integration.
 
 ### Containerization (Docker / Docker Compose)
 
@@ -56,25 +56,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Verify with: Run the unit tests with coverage enabled and confirm that a coverage report is produced and that the configured threshold (around 80%) is enforced for new changes.
-- Common tools: jest, nyc. Example config files: jest.config.\*.
 - Bazel commands: `bazel coverage //...`.
 - Bazel coverage collects coverage data from all test targets. Use --combined_report=lcov for aggregated reports.
+- Common tools: jest, nyc. Example config files: jest.config.\*.
 
 ### CI Quality Gates
 
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Verify with: Open the CI configuration and verify there is a job or stage that runs linting, type checking, tests, build, and any required container checks before merging to main.
-- Example config files: .github/workflows/\*, azure-pipelines.yml.
 - Bazel commands: `bazel build //...`, `bazel test //...`.
 - Replace npm run ci with Bazel commands. All quality gates run as Bazel targets.
+- Example config files: .github/workflows/\*, azure-pipelines.yml.
 
 ### Code Formatter
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Verify with: Run the formatter in check mode (for example, `npm run format:check`) and confirm it reports clean formatting on committed code and auto-fixes as expected locally.
-- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 - Bazel commands: `bazel run //tools/format:check`, `bazel test //...:format_test`.
 - Wrap Prettier as a run target for formatting checks. Use aspect_rules_lint for format aspects.
+- Common tools: prettier. Example config files: .prettierrc.\*, .prettierignore.
 
 ### Pre-Commit Hooks
 
@@ -89,7 +89,7 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Verify with: Presence of tsconfig.json indicates type-checking is configured for the repository.
 - Ensure tsconfig.json exists in the repository.
 - Define a `typecheck` script or equivalent command.
-- Common tools: TypeScript compiler (tsc). Example config files: tsconfig.json.
+- Bazel commands: `bazel build //...`.
 
 ### Dependency Management & Vulnerability Scanning
 

--- a/instructions.typescript-js.md
+++ b/instructions.typescript-js.md
@@ -1,7 +1,7 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config/standards.typescript-js.github-actions.json`
-> Stack: TypeScript / JavaScript | CI: github-actions
+> Auto-generated from `config/standards.typescript-js.json`
+> Stack: TypeScript / JavaScript | CI: azure-devops, github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
 

--- a/scripts/generate-instructions.ts
+++ b/scripts/generate-instructions.ts
@@ -60,65 +60,104 @@ function generateBullets(item: ChecklistItem): string[] {
   // Bullet 1: Core purpose from description
   bullets.push(item.description);
 
-  // Bullet 2: Verification guidance
+  addVerificationBullet(bullets, stack);
+  addRequiredFilesBullet(bullets, stack);
+  addRequiredScriptsBullet(bullets, stack);
+  addMachineCheckBullet(bullets, stack);
+  addExamplesBullet(bullets, stack);
+  addPinningNotesBullet(bullets, stack);
+  addOptionalFilesBullet(bullets, stack);
+  addBazelBullets(bullets, stack);
+  addNotesBullet(bullets, stack);
+
+  // Limit to 5 bullets
+  return bullets.slice(0, 5);
+}
+
+function addVerificationBullet(bullets: string[], stack?: StackHints) {
   if (stack?.verification) {
     bullets.push(`Verify with: ${stack.verification}`);
   }
+}
 
-  // Bullet 3: Required files / any-of files
-  if (stack?.requiredFiles?.length || stack?.anyOfFiles?.length) {
-    const requiredFiles = stack?.requiredFiles?.join(", ");
-    const anyOfFiles = stack?.anyOfFiles?.join(", ");
-    if (requiredFiles && anyOfFiles) {
-      bullets.push(
-        `Ensure ${requiredFiles} exists, and at least one of ${anyOfFiles} is present.`,
-      );
-    } else if (requiredFiles) {
-      bullets.push(`Ensure ${requiredFiles} exists in the repository.`);
-    } else if (anyOfFiles) {
-      bullets.push(`Ensure at least one of ${anyOfFiles} is present.`);
-    }
+function addRequiredFilesBullet(bullets: string[], stack?: StackHints) {
+  if (!stack?.requiredFiles?.length && !stack?.anyOfFiles?.length) {
+    return;
   }
 
-  // Bullet 4: Required scripts
-  if (stack?.requiredScripts?.length) {
-    const scripts = stack.requiredScripts.map((s) => `\`${s}\``).join(", ");
-    bullets.push(`Define a ${scripts} script or equivalent command.`);
-  }
+  const requiredFiles = stack?.requiredFiles?.join(", ");
+  const anyOfFiles = stack?.anyOfFiles?.join(", ");
 
-  // Bullet 5: Machine check hint
-  if (stack?.machineCheck) {
-    const description = stack.machineCheck.description
-      ? `${stack.machineCheck.description} `
-      : "";
-    const expectCode = stack.machineCheck.expectExitCode ?? 0;
+  if (requiredFiles && anyOfFiles) {
     bullets.push(
-      `${description}Run \`${stack.machineCheck.command}\` (expect exit code ${expectCode}).`,
+      `Ensure ${requiredFiles} exists, and at least one of ${anyOfFiles} is present.`,
     );
+    return;
   }
 
-  if (stack?.exampleTools?.length || stack?.exampleConfigFiles?.length) {
-    const tools = stack.exampleTools?.join(", ");
-    const configs = stack.exampleConfigFiles?.join(", ");
-    if (tools && configs) {
-      bullets.push(`Common tools: ${tools}. Example config files: ${configs}.`);
-    } else if (tools) {
-      bullets.push(`Common tools: ${tools}.`);
-    } else if (configs) {
-      bullets.push(`Example config files: ${configs}.`);
-    }
+  if (requiredFiles) {
+    bullets.push(`Ensure ${requiredFiles} exists in the repository.`);
+    return;
   }
 
+  if (anyOfFiles) {
+    bullets.push(`Ensure at least one of ${anyOfFiles} is present.`);
+  }
+}
+
+function addRequiredScriptsBullet(bullets: string[], stack?: StackHints) {
+  if (!stack?.requiredScripts?.length) {
+    return;
+  }
+
+  const scripts = stack.requiredScripts.map((s) => `\`${s}\``).join(", ");
+  bullets.push(`Define a ${scripts} script or equivalent command.`);
+}
+
+function addMachineCheckBullet(bullets: string[], stack?: StackHints) {
+  if (!stack?.machineCheck) {
+    return;
+  }
+
+  const description = stack.machineCheck.description
+    ? `${stack.machineCheck.description} `
+    : "";
+  const expectCode = stack.machineCheck.expectExitCode ?? 0;
+  bullets.push(
+    `${description}Run \`${stack.machineCheck.command}\` (expect exit code ${expectCode}).`,
+  );
+}
+
+function addExamplesBullet(bullets: string[], stack?: StackHints) {
+  const tools = stack?.exampleTools?.join(", ");
+  const configs = stack?.exampleConfigFiles?.join(", ");
+
+  if (tools && configs) {
+    bullets.push(`Common tools: ${tools}. Example config files: ${configs}.`);
+  } else if (tools) {
+    bullets.push(`Common tools: ${tools}.`);
+  } else if (configs) {
+    bullets.push(`Example config files: ${configs}.`);
+  }
+}
+
+function addPinningNotesBullet(bullets: string[], stack?: StackHints) {
   if (stack?.pinningNotes) {
     bullets.push(stack.pinningNotes);
   }
+}
 
-  if (stack?.optionalFiles?.length) {
-    const files = stack.optionalFiles.slice(0, 3).join(", ");
-    const more = stack.optionalFiles.length > 3 ? " and others" : "";
-    bullets.push(`Consider adding ${files}${more} if applicable.`);
+function addOptionalFilesBullet(bullets: string[], stack?: StackHints) {
+  if (!stack?.optionalFiles?.length) {
+    return;
   }
 
+  const files = stack.optionalFiles.slice(0, 3).join(", ");
+  const more = stack.optionalFiles.length > 3 ? " and others" : "";
+  bullets.push(`Consider adding ${files}${more} if applicable.`);
+}
+
+function addBazelBullets(bullets: string[], stack?: StackHints) {
   if (stack?.bazelHints?.commands?.length) {
     const commands = stack.bazelHints.commands.map((cmd) => `\`${cmd}\``);
     bullets.push(`Bazel commands: ${commands.join(", ")}.`);
@@ -132,14 +171,12 @@ function generateBullets(item: ChecklistItem): string[] {
   if (stack?.bazelHints?.notes) {
     bullets.push(stack.bazelHints.notes);
   }
+}
 
-  // Notes-based guidance (if short enough)
+function addNotesBullet(bullets: string[], stack?: StackHints) {
   if (stack?.notes && stack.notes.length < 150) {
     bullets.push(stack.notes);
   }
-
-  // Limit to 5 bullets
-  return bullets.slice(0, 5);
 }
 
 function generateSection(title: string, items: ChecklistItem[]): string {

--- a/scripts/generate-instructions.ts
+++ b/scripts/generate-instructions.ts
@@ -64,10 +64,10 @@ function generateBullets(item: ChecklistItem): string[] {
   addRequiredFilesBullet(bullets, stack);
   addRequiredScriptsBullet(bullets, stack);
   addMachineCheckBullet(bullets, stack);
+  addBazelBullets(bullets, stack);
   addExamplesBullet(bullets, stack);
   addPinningNotesBullet(bullets, stack);
   addOptionalFilesBullet(bullets, stack);
-  addBazelBullets(bullets, stack);
   addNotesBullet(bullets, stack);
 
   // Limit to 5 bullets

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -34,9 +34,9 @@ describe("repo-standards API", () => {
 });
 
 describe("dependency governance items", () => {
-  it("schema version is 2", () => {
+  it("schema version is 3", () => {
     const spec = loadMasterSpec();
-    expect(spec.version).toBe(2);
+    expect(spec.version).toBe(3);
   });
 
   it("recommended section includes both dependency items", () => {


### PR DESCRIPTION
### Motivation

- Align the standards schema major version with the package major version so tests and validation remain consistent.
- Preserve and surface new `stackHints` metadata (verification, `anyOfFiles`, `pinningNotes`, `machineCheck`, `bazelHints`, etc.) for downstream consumers and human-facing docs.
- Improve the instructions generator to emit machine-friendly and Bazel-related hints for stack-specific guidance.

### Description

- Bumped schema `version` from `2` to `3` in `config/standards.json` and in all generated per-stack `config/standards.*.json` outputs, and updated `README.md` to document the new schema major.
- Extended `scripts/generate-instructions.ts` to render `anyOfFiles`, `pinningNotes`, `machineCheck`, `bazelHints`, and include `exampleTools`/`exampleConfigFiles` and optional/required file logic in generated bullets.
- Regenerated all stack/CI-specific standards JSON files under `config/` and produced updated `instructions.*.md` files (multiple new/updated `instructions.*.md`).
- Updated tests to expect schema version `3` by adjusting `src/index.test.ts` and kept generator/test assumptions in sync with the new schema.

### Testing

- Regenerated per-stack outputs using `npx tsx scripts/generate-standards.ts` and `scripts/generate-instructions.ts` and wrote updated `config/standards.*.json` and `instructions.*.md` artifacts successfully.
- Ran code formatting with `npm run format` to normalize generated files and satisfy Prettier checks.
- Executed the full CI checks via `npm run ci`, which completed successfully (lint/typecheck/tests/build passed).
- Unit tests now pass (all tests green after the schema and test updates).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6956fe3de120832bb0826731933aff52)