### PR TITLE
feat!: harden standards API with stable contract and Node 22 LTS

### DIFF
--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["azure-devops"],
@@ -178,7 +178,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -187,14 +187,42 @@
         "stack": {
           "exampleTools": ["GitVersion"],
           "exampleConfigFiles": ["GitVersion.yml", "*.csproj", "CHANGELOG.md"],
-          "notes": "Use GitVersion to automatically compute SemVer from git history and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with release pipeline to automatically version assemblies, NuGet packages, and create release notes.",
-          "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI automatically produces the expected version metadata, updates project files, and generates changelog entries from commit history."
+          "notes": "Use GitVersion (or Directory.Build.props) as the single canonical version source, computed from git history, and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with the release pipeline to version assemblies, NuGet packages, and publish GitHub releases from the same version.",
+          "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI produces the expected version metadata, updates project files, and generates changelog entries from commit history.",
+          "requiredFiles": ["*.csproj"],
+          "optionalFiles": [
+            "GitVersion.yml",
+            "Directory.Build.props",
+            "CHANGELOG.md"
+          ],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["GitVersion", "dotnet pack", "dotnet nuget push"],
+          "exampleConfigFiles": [
+            "azure-pipelines.yml",
+            ".github/workflows/release.yml"
+          ],
+          "notes": "Use a single release pipeline to publish NuGet packages, GitHub releases, and Docker images from the canonical version source (GitVersion or Directory.Build.props).",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["GitVersion.yml", "Directory.Build.props"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -203,8 +231,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.*", ".cz.toml"],
-          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it.",
-          "verification": "Create a test commit following the documented commit convention and confirm that any configured commit message checks (local hooks or CI) accept the message."
+          "notes": "Document your Conventional Commit convention and enforce it via commit-msg hooks and CI so release tooling can compute versions deterministically.",
+          "verification": "Create a test commit following the documented convention and confirm that commit-msg hooks and CI checks accept it.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -288,7 +324,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -326,6 +362,67 @@
           "notes": "Enable package lock files and use vulnerability scanning to track and remediate high-risk dependencies.",
           "verification": "Dependency lockfile or package reference is present; security scanning is configured.",
           "optionalFiles": ["packages.lock.json"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": ["dotnet restore --locked-mode"],
+          "exampleConfigFiles": ["packages.lock.json", "global.json"],
+          "notes": "Enable packages.lock.json and use locked restore. Pin SDK versions via global.json and pin base images in Dockerfiles.",
+          "verification": "packages.lock.json or equivalent lock files exist and restore runs in locked mode. SDK versions are pinned.",
+          "optionalFiles": ["packages.lock.json", "global.json"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": ["sbom-tool", "codeql", "gitleaks", "cosign"],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for NuGet and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/pack/release stages to standardize across .NET repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["github-actions"],
@@ -178,7 +178,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -187,14 +187,42 @@
         "stack": {
           "exampleTools": ["GitVersion"],
           "exampleConfigFiles": ["GitVersion.yml", "*.csproj", "CHANGELOG.md"],
-          "notes": "Use GitVersion to automatically compute SemVer from git history and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with release pipeline to automatically version assemblies, NuGet packages, and create release notes.",
-          "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI automatically produces the expected version metadata, updates project files, and generates changelog entries from commit history."
+          "notes": "Use GitVersion (or Directory.Build.props) as the single canonical version source, computed from git history, and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with the release pipeline to version assemblies, NuGet packages, and publish GitHub releases from the same version.",
+          "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI produces the expected version metadata, updates project files, and generates changelog entries from commit history.",
+          "requiredFiles": ["*.csproj"],
+          "optionalFiles": [
+            "GitVersion.yml",
+            "Directory.Build.props",
+            "CHANGELOG.md"
+          ],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["GitVersion", "dotnet pack", "dotnet nuget push"],
+          "exampleConfigFiles": [
+            "azure-pipelines.yml",
+            ".github/workflows/release.yml"
+          ],
+          "notes": "Use a single release pipeline to publish NuGet packages, GitHub releases, and Docker images from the canonical version source (GitVersion or Directory.Build.props).",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["GitVersion.yml", "Directory.Build.props"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -203,8 +231,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.*", ".cz.toml"],
-          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it.",
-          "verification": "Create a test commit following the documented commit convention and confirm that any configured commit message checks (local hooks or CI) accept the message."
+          "notes": "Document your Conventional Commit convention and enforce it via commit-msg hooks and CI so release tooling can compute versions deterministically.",
+          "verification": "Create a test commit following the documented convention and confirm that commit-msg hooks and CI checks accept it.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -288,7 +324,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -326,6 +362,67 @@
           "notes": "Enable package lock files and use vulnerability scanning to track and remediate high-risk dependencies.",
           "verification": "Dependency lockfile or package reference is present; security scanning is configured.",
           "optionalFiles": ["packages.lock.json"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["dotnet restore --locked-mode"],
+          "exampleConfigFiles": ["packages.lock.json", "global.json"],
+          "notes": "Enable packages.lock.json and use locked restore. Pin SDK versions via global.json and pin base images in Dockerfiles.",
+          "verification": "packages.lock.json or equivalent lock files exist and restore runs in locked mode. SDK versions are pinned.",
+          "optionalFiles": ["packages.lock.json", "global.json"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": ["sbom-tool", "codeql", "gitleaks", "cosign"],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for NuGet and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/pack/release stages to standardize across .NET repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "csharp-dotnet",
   "stackLabel": "C# / .NET",
   "ciSystems": ["azure-devops", "github-actions"],
@@ -190,7 +190,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -202,14 +202,45 @@
         "stack": {
           "exampleTools": ["GitVersion"],
           "exampleConfigFiles": ["GitVersion.yml", "*.csproj", "CHANGELOG.md"],
-          "notes": "Use GitVersion to automatically compute SemVer from git history and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with release pipeline to automatically version assemblies, NuGet packages, and create release notes.",
-          "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI automatically produces the expected version metadata, updates project files, and generates changelog entries from commit history."
+          "notes": "Use GitVersion (or Directory.Build.props) as the single canonical version source, computed from git history, and feed it into assembly/package versions. Configure CI to auto-generate or update CHANGELOG.md from commit messages and git tags. Integrate with the release pipeline to version assemblies, NuGet packages, and publish GitHub releases from the same version.",
+          "verification": "Check that versioning is driven by a SemVer-aware tool (for example, GitVersion) and verify that running the release/versioning step locally or in CI produces the expected version metadata, updates project files, and generates changelog entries from commit history.",
+          "requiredFiles": ["*.csproj"],
+          "optionalFiles": [
+            "GitVersion.yml",
+            "Directory.Build.props",
+            "CHANGELOG.md"
+          ],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["GitVersion", "dotnet pack", "dotnet nuget push"],
+          "exampleConfigFiles": [
+            "azure-pipelines.yml",
+            ".github/workflows/release.yml"
+          ],
+          "notes": "Use a single release pipeline to publish NuGet packages, GitHub releases, and Docker images from the canonical version source (GitVersion or Directory.Build.props).",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["GitVersion.yml", "Directory.Build.props"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -221,8 +252,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.*", ".cz.toml"],
-          "notes": "Document your commit convention and wire up a helper tool so contributors can easily follow it.",
-          "verification": "Create a test commit following the documented commit convention and confirm that any configured commit message checks (local hooks or CI) accept the message."
+          "notes": "Document your Conventional Commit convention and enforce it via commit-msg hooks and CI so release tooling can compute versions deterministically.",
+          "verification": "Create a test commit following the documented convention and confirm that commit-msg hooks and CI checks accept it.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -318,7 +357,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -362,6 +401,76 @@
           "notes": "Enable package lock files and use vulnerability scanning to track and remediate high-risk dependencies.",
           "verification": "Dependency lockfile or package reference is present; security scanning is configured.",
           "optionalFiles": ["packages.lock.json"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["dotnet restore --locked-mode"],
+          "exampleConfigFiles": ["packages.lock.json", "global.json"],
+          "notes": "Enable packages.lock.json and use locked restore. Pin SDK versions via global.json and pin base images in Dockerfiles.",
+          "verification": "packages.lock.json or equivalent lock files exist and restore runs in locked mode. SDK versions are pinned.",
+          "optionalFiles": ["packages.lock.json", "global.json"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          },
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": ["sbom-tool", "codeql", "gitleaks", "cosign"],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for NuGet and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/pack/release stages to standardize across .NET repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["azure-devops"],
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -188,14 +188,37 @@
         "stack": {
           "exampleTools": ["goreleaser", "semantic-release"],
           "exampleConfigFiles": [".goreleaser.yml", "CHANGELOG.md"],
-          "notes": "Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.",
-          "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs."
+          "notes": "Go uses git tags (v1.2.3) as the canonical version source. Use goreleaser for automated releases with changelog generation and publish GitHub/Docker artifacts from the same tag.",
+          "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tooling generates releases and changelogs.",
+          "optionalFiles": [".goreleaser.yml", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["goreleaser", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline (goreleaser or equivalent) to publish GitHub releases and Docker images from the same git tag.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": [".goreleaser.yml", "CHANGELOG.md"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -204,8 +227,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.",
-          "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+          "notes": "Use commitlint with commit-msg or pre-commit hooks plus a CI check. Conventional Commits keep goreleaser changelog generation deterministic.",
+          "verification": "Test that non-conforming commit messages are rejected by the configured hooks and CI check.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -287,7 +318,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -320,6 +351,74 @@
           "notes": "Use govulncheck (official Go tool) for vulnerability scanning. go.sum locks dependency checksums for reproducible builds.",
           "verification": "go.sum is present; run 'govulncheck ./...' to verify security scanning.",
           "requiredFiles": ["go.sum"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": ["go env -w GOPROXY=off", "go mod download"],
+          "exampleConfigFiles": ["go.sum", "go.mod", ".go-version"],
+          "notes": "Use go.sum for deterministic module versions and pin Go versions (go.mod + .go-version). Avoid network variance by caching modules and pinning proxies.",
+          "verification": "go.sum is present and builds use pinned Go versions; module downloads are cached.",
+          "requiredFiles": ["go.sum"],
+          "optionalFiles": [".go-version"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "syft",
+            "cyclonedx-gomod",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for Go binaries and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/release stages to standardize across Go repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["github-actions"],
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -188,14 +188,37 @@
         "stack": {
           "exampleTools": ["goreleaser", "semantic-release"],
           "exampleConfigFiles": [".goreleaser.yml", "CHANGELOG.md"],
-          "notes": "Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.",
-          "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs."
+          "notes": "Go uses git tags (v1.2.3) as the canonical version source. Use goreleaser for automated releases with changelog generation and publish GitHub/Docker artifacts from the same tag.",
+          "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tooling generates releases and changelogs.",
+          "optionalFiles": [".goreleaser.yml", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["goreleaser", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline (goreleaser or equivalent) to publish GitHub releases and Docker images from the same git tag.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": [".goreleaser.yml", "CHANGELOG.md"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -204,8 +227,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.",
-          "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+          "notes": "Use commitlint with commit-msg or pre-commit hooks plus a CI check. Conventional Commits keep goreleaser changelog generation deterministic.",
+          "verification": "Test that non-conforming commit messages are rejected by the configured hooks and CI check.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -287,7 +318,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -320,6 +351,74 @@
           "notes": "Use govulncheck (official Go tool) for vulnerability scanning. go.sum locks dependency checksums for reproducible builds.",
           "verification": "go.sum is present; run 'govulncheck ./...' to verify security scanning.",
           "requiredFiles": ["go.sum"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["go env -w GOPROXY=off", "go mod download"],
+          "exampleConfigFiles": ["go.sum", "go.mod", ".go-version"],
+          "notes": "Use go.sum for deterministic module versions and pin Go versions (go.mod + .go-version). Avoid network variance by caching modules and pinning proxies.",
+          "verification": "go.sum is present and builds use pinned Go versions; module downloads are cached.",
+          "requiredFiles": ["go.sum"],
+          "optionalFiles": [".go-version"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "syft",
+            "cyclonedx-gomod",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for Go binaries and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/release stages to standardize across Go repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "go",
   "stackLabel": "Go",
   "ciSystems": ["azure-devops", "github-actions"],
@@ -191,7 +191,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -203,14 +203,40 @@
         "stack": {
           "exampleTools": ["goreleaser", "semantic-release"],
           "exampleConfigFiles": [".goreleaser.yml", "CHANGELOG.md"],
-          "notes": "Go uses git tags for versioning (v1.2.3 format). Use goreleaser for automated releases with changelog generation. Tag versions consistently.",
-          "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tool generates releases and changelogs."
+          "notes": "Go uses git tags (v1.2.3) as the canonical version source. Use goreleaser for automated releases with changelog generation and publish GitHub/Docker artifacts from the same tag.",
+          "verification": "Check that git tags follow vMAJOR.MINOR.PATCH format and goreleaser or similar tooling generates releases and changelogs.",
+          "optionalFiles": [".goreleaser.yml", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["goreleaser", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline (goreleaser or equivalent) to publish GitHub releases and Docker images from the same git tag.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": [".goreleaser.yml", "CHANGELOG.md"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -222,8 +248,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with pre-commit hooks for enforcing Conventional Commits. Consistent with goreleaser changelog generation.",
-          "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+          "notes": "Use commitlint with commit-msg or pre-commit hooks plus a CI check. Conventional Commits keep goreleaser changelog generation deterministic.",
+          "verification": "Test that non-conforming commit messages are rejected by the configured hooks and CI check.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -317,7 +351,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -356,6 +390,83 @@
           "notes": "Use govulncheck (official Go tool) for vulnerability scanning. go.sum locks dependency checksums for reproducible builds.",
           "verification": "go.sum is present; run 'govulncheck ./...' to verify security scanning.",
           "requiredFiles": ["go.sum"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["go env -w GOPROXY=off", "go mod download"],
+          "exampleConfigFiles": ["go.sum", "go.mod", ".go-version"],
+          "notes": "Use go.sum for deterministic module versions and pin Go versions (go.mod + .go-version). Avoid network variance by caching modules and pinning proxies.",
+          "verification": "go.sum is present and builds use pinned Go versions; module downloads are cached.",
+          "requiredFiles": ["go.sum"],
+          "optionalFiles": [".go-version"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          },
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "syft",
+            "cyclonedx-gomod",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for Go binaries and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/release stages to standardize across Go repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["azure-devops"],
@@ -184,7 +184,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -193,14 +193,38 @@
         "stack": {
           "exampleTools": ["bumpversion", "setuptools_scm", "towncrier"],
           "exampleConfigFiles": ["pyproject.toml", "setup.cfg", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Configure CI to automatically update version in pyproject.toml, generate/update CHANGELOG.md from commit messages or changelog fragments, and create git tags. Maintain a single source of truth for versioning.",
-          "verification": "Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments."
+          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Keep pyproject.toml (or VERSION) as the single canonical version source, and have CI publish GitHub/PyPI/Docker artifacts from that same version.",
+          "verification": "Check that the canonical version in pyproject.toml or VERSION follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) computes or bumps the version and generates changelog entries from commit history or fragments.",
+          "requiredFiles": ["pyproject.toml"],
+          "optionalFiles": ["VERSION", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["setuptools_scm", "twine", "build", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline to publish PyPI packages, GitHub releases, and Docker images from the canonical version source (pyproject.toml or VERSION).",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md", "VERSION"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -209,8 +233,16 @@
         "stack": {
           "exampleTools": ["commitizen"],
           "exampleConfigFiles": [".cz.toml", "pyproject.toml"],
-          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes.",
-          "verification": "Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted."
+          "notes": "Standardize Conventional Commits using commitizen or commitlint with commit-msg hooks plus CI so changelog generation is deterministic.",
+          "verification": "Use the configured commit helper or hooks to create a test commit and confirm that non-conforming messages are rejected locally and in CI.",
+          "anyOfFiles": [
+            ".cz.toml",
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -292,7 +324,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -305,6 +337,7 @@
           "verification": "pyproject.toml (or mypy.ini) signals that mypy configuration is available for the repository.",
           "requiredFiles": ["pyproject.toml"],
           "optionalFiles": ["mypy.ini"],
+          "requiredScripts": ["typecheck"],
           "bazelHints": {
             "commands": [
               "bazel test //...:mypy_test",
@@ -333,6 +366,78 @@
           "notes": "Pin dependency versions and routinely scan for vulnerabilities, prioritizing fixes for critical and high-severity issues.",
           "verification": "Dependency lockfile is present; security scanning is configured in CI or project tooling.",
           "optionalFiles": ["requirements.txt", "Pipfile.lock", "poetry.lock"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": ["pip-tools", "poetry", "uv"],
+          "exampleConfigFiles": [
+            "requirements.txt",
+            "poetry.lock",
+            "Pipfile.lock"
+          ],
+          "notes": "Use pinned lockfiles (requirements.txt or poetry.lock) and pin Python version (.python-version or tool-versions). Avoid non-deterministic installs in CI.",
+          "verification": "Lockfile is present and CI installs with pinned versions only. Python runtime is pinned.",
+          "anyOfFiles": ["requirements.txt", "poetry.lock", "Pipfile.lock"],
+          "optionalFiles": [".python-version", ".tool-versions"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "cyclonedx-python",
+            "syft",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for PyPI and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for lint/test/typecheck/release stages to standardize across Python repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["github-actions"],
@@ -184,7 +184,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -193,14 +193,38 @@
         "stack": {
           "exampleTools": ["bumpversion", "setuptools_scm", "towncrier"],
           "exampleConfigFiles": ["pyproject.toml", "setup.cfg", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Configure CI to automatically update version in pyproject.toml, generate/update CHANGELOG.md from commit messages or changelog fragments, and create git tags. Maintain a single source of truth for versioning.",
-          "verification": "Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments."
+          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Keep pyproject.toml (or VERSION) as the single canonical version source, and have CI publish GitHub/PyPI/Docker artifacts from that same version.",
+          "verification": "Check that the canonical version in pyproject.toml or VERSION follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) computes or bumps the version and generates changelog entries from commit history or fragments.",
+          "requiredFiles": ["pyproject.toml"],
+          "optionalFiles": ["VERSION", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["setuptools_scm", "twine", "build", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline to publish PyPI packages, GitHub releases, and Docker images from the canonical version source (pyproject.toml or VERSION).",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md", "VERSION"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -209,8 +233,16 @@
         "stack": {
           "exampleTools": ["commitizen"],
           "exampleConfigFiles": [".cz.toml", "pyproject.toml"],
-          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes.",
-          "verification": "Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted."
+          "notes": "Standardize Conventional Commits using commitizen or commitlint with commit-msg hooks plus CI so changelog generation is deterministic.",
+          "verification": "Use the configured commit helper or hooks to create a test commit and confirm that non-conforming messages are rejected locally and in CI.",
+          "anyOfFiles": [
+            ".cz.toml",
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -292,7 +324,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -305,6 +337,7 @@
           "verification": "pyproject.toml (or mypy.ini) signals that mypy configuration is available for the repository.",
           "requiredFiles": ["pyproject.toml"],
           "optionalFiles": ["mypy.ini"],
+          "requiredScripts": ["typecheck"],
           "bazelHints": {
             "commands": [
               "bazel test //...:mypy_test",
@@ -333,6 +366,78 @@
           "notes": "Pin dependency versions and routinely scan for vulnerabilities, prioritizing fixes for critical and high-severity issues.",
           "verification": "Dependency lockfile is present; security scanning is configured in CI or project tooling.",
           "optionalFiles": ["requirements.txt", "Pipfile.lock", "poetry.lock"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["pip-tools", "poetry", "uv"],
+          "exampleConfigFiles": [
+            "requirements.txt",
+            "poetry.lock",
+            "Pipfile.lock"
+          ],
+          "notes": "Use pinned lockfiles (requirements.txt or poetry.lock) and pin Python version (.python-version or tool-versions). Avoid non-deterministic installs in CI.",
+          "verification": "Lockfile is present and CI installs with pinned versions only. Python runtime is pinned.",
+          "anyOfFiles": ["requirements.txt", "poetry.lock", "Pipfile.lock"],
+          "optionalFiles": [".python-version", ".tool-versions"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "cyclonedx-python",
+            "syft",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for PyPI and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for lint/test/typecheck/release stages to standardize across Python repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "python",
   "stackLabel": "Python",
   "ciSystems": ["azure-devops", "github-actions"],
@@ -196,7 +196,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -208,14 +208,41 @@
         "stack": {
           "exampleTools": ["bumpversion", "setuptools_scm", "towncrier"],
           "exampleConfigFiles": ["pyproject.toml", "setup.cfg", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Configure CI to automatically update version in pyproject.toml, generate/update CHANGELOG.md from commit messages or changelog fragments, and create git tags. Maintain a single source of truth for versioning.",
-          "verification": "Check that the package version in pyproject or setup configuration follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) automatically computes or bumps the version and generates changelog entries from commit history or fragments."
+          "notes": "Automate version bumping and changelog generation using setuptools_scm (git-tag based) or bumpversion with towncrier for changelog fragments. Keep pyproject.toml (or VERSION) as the single canonical version source, and have CI publish GitHub/PyPI/Docker artifacts from that same version.",
+          "verification": "Check that the canonical version in pyproject.toml or VERSION follows SemVer and verify that the configured tool (for example, setuptools_scm or bumpversion) computes or bumps the version and generates changelog entries from commit history or fragments.",
+          "requiredFiles": ["pyproject.toml"],
+          "optionalFiles": ["VERSION", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["setuptools_scm", "twine", "build", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline to publish PyPI packages, GitHub releases, and Docker images from the canonical version source (pyproject.toml or VERSION).",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md", "VERSION"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -227,8 +254,16 @@
         "stack": {
           "exampleTools": ["commitizen"],
           "exampleConfigFiles": [".cz.toml", "pyproject.toml"],
-          "notes": "Standardize commit messages using commitizen or a similar helper and document the required types and scopes.",
-          "verification": "Use the configured commit helper (for example, commitizen) or hooks to create a test commit and confirm that non-conforming messages are rejected while valid ones are accepted."
+          "notes": "Standardize Conventional Commits using commitizen or commitlint with commit-msg hooks plus CI so changelog generation is deterministic.",
+          "verification": "Use the configured commit helper or hooks to create a test commit and confirm that non-conforming messages are rejected locally and in CI.",
+          "anyOfFiles": [
+            ".cz.toml",
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -322,7 +357,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -338,6 +373,7 @@
           "verification": "pyproject.toml (or mypy.ini) signals that mypy configuration is available for the repository.",
           "requiredFiles": ["pyproject.toml"],
           "optionalFiles": ["mypy.ini"],
+          "requiredScripts": ["typecheck"],
           "bazelHints": {
             "commands": [
               "bazel test //...:mypy_test",
@@ -369,6 +405,87 @@
           "notes": "Pin dependency versions and routinely scan for vulnerabilities, prioritizing fixes for critical and high-severity issues.",
           "verification": "Dependency lockfile is present; security scanning is configured in CI or project tooling.",
           "optionalFiles": ["requirements.txt", "Pipfile.lock", "poetry.lock"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["pip-tools", "poetry", "uv"],
+          "exampleConfigFiles": [
+            "requirements.txt",
+            "poetry.lock",
+            "Pipfile.lock"
+          ],
+          "notes": "Use pinned lockfiles (requirements.txt or poetry.lock) and pin Python version (.python-version or tool-versions). Avoid non-deterministic installs in CI.",
+          "verification": "Lockfile is present and CI installs with pinned versions only. Python runtime is pinned.",
+          "anyOfFiles": ["requirements.txt", "poetry.lock", "Pipfile.lock"],
+          "optionalFiles": [".python-version", ".tool-versions"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          },
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "cyclonedx-python",
+            "syft",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for PyPI and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for lint/test/typecheck/release stages to standardize across Python repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["azure-devops"],
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -188,14 +188,38 @@
         "stack": {
           "exampleTools": ["cargo-release", "semantic-release"],
           "exampleConfigFiles": ["Cargo.toml", "CHANGELOG.md"],
-          "notes": "Version is defined in Cargo.toml. Use cargo-release or semantic-release-cargo for automated versioning. Follow Conventional Commits for changelog generation.",
-          "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history."
+          "notes": "Version is defined in Cargo.toml as the canonical source. Use cargo-release or semantic-release-cargo for automated versioning and GitHub release publishing, and follow Conventional Commits for changelog generation.",
+          "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history.",
+          "requiredFiles": ["Cargo.toml"],
+          "optionalFiles": ["CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["cargo-release", "cargo publish", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline to publish crates.io packages, GitHub releases, and Docker images from the Cargo.toml version.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -204,8 +228,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.",
-          "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits and add a CI check to keep version/changelog automation deterministic.",
+          "verification": "Test that non-conforming commit messages are rejected by the configured hooks and CI check.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -289,7 +321,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -324,6 +356,74 @@
           "optionalFiles": ["deny.toml"],
           "anyOfFiles": ["Cargo.lock"],
           "pinningNotes": "Required for binaries/services; optional for libraries (add to .gitignore for libs). See https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control"
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": ["cargo build --locked"],
+          "exampleConfigFiles": ["Cargo.lock", "rust-toolchain.toml"],
+          "notes": "Commit Cargo.lock for binaries/services and pin Rust versions with rust-toolchain.toml. Use --locked in CI.",
+          "verification": "Cargo.lock is present and CI uses --locked. Rust toolchain is pinned.",
+          "requiredFiles": ["Cargo.lock"],
+          "optionalFiles": ["rust-toolchain.toml"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "cargo-cyclonedx",
+            "syft",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for crates and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/release stages to standardize across Rust repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["github-actions"],
@@ -179,7 +179,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -188,14 +188,38 @@
         "stack": {
           "exampleTools": ["cargo-release", "semantic-release"],
           "exampleConfigFiles": ["Cargo.toml", "CHANGELOG.md"],
-          "notes": "Version is defined in Cargo.toml. Use cargo-release or semantic-release-cargo for automated versioning. Follow Conventional Commits for changelog generation.",
-          "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history."
+          "notes": "Version is defined in Cargo.toml as the canonical source. Use cargo-release or semantic-release-cargo for automated versioning and GitHub release publishing, and follow Conventional Commits for changelog generation.",
+          "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history.",
+          "requiredFiles": ["Cargo.toml"],
+          "optionalFiles": ["CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["cargo-release", "cargo publish", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline to publish crates.io packages, GitHub releases, and Docker images from the Cargo.toml version.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -204,8 +228,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.",
-          "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits and add a CI check to keep version/changelog automation deterministic.",
+          "verification": "Test that non-conforming commit messages are rejected by the configured hooks and CI check.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -289,7 +321,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -324,6 +356,74 @@
           "optionalFiles": ["deny.toml"],
           "anyOfFiles": ["Cargo.lock"],
           "pinningNotes": "Required for binaries/services; optional for libraries (add to .gitignore for libs). See https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control"
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["cargo build --locked"],
+          "exampleConfigFiles": ["Cargo.lock", "rust-toolchain.toml"],
+          "notes": "Commit Cargo.lock for binaries/services and pin Rust versions with rust-toolchain.toml. Use --locked in CI.",
+          "verification": "Cargo.lock is present and CI uses --locked. Rust toolchain is pinned.",
+          "requiredFiles": ["Cargo.lock"],
+          "optionalFiles": ["rust-toolchain.toml"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "cargo-cyclonedx",
+            "syft",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for crates and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/release stages to standardize across Rust repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "rust",
   "stackLabel": "Rust",
   "ciSystems": ["azure-devops", "github-actions"],
@@ -191,7 +191,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -203,14 +203,41 @@
         "stack": {
           "exampleTools": ["cargo-release", "semantic-release"],
           "exampleConfigFiles": ["Cargo.toml", "CHANGELOG.md"],
-          "notes": "Version is defined in Cargo.toml. Use cargo-release or semantic-release-cargo for automated versioning. Follow Conventional Commits for changelog generation.",
-          "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history."
+          "notes": "Version is defined in Cargo.toml as the canonical source. Use cargo-release or semantic-release-cargo for automated versioning and GitHub release publishing, and follow Conventional Commits for changelog generation.",
+          "verification": "Check that Cargo.toml version follows SemVer and verify changelog generation from commit history.",
+          "requiredFiles": ["Cargo.toml"],
+          "optionalFiles": ["CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": ["cargo-release", "cargo publish", "docker buildx"],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use a single release pipeline to publish crates.io packages, GitHub releases, and Docker images from the Cargo.toml version.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -222,8 +249,16 @@
         "stack": {
           "exampleTools": ["commitlint", "commitizen"],
           "exampleConfigFiles": ["commitlint.config.js", ".cz.toml"],
-          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits. Works consistently with cargo workspaces.",
-          "verification": "Test that non-conforming commit messages are rejected by the configured hooks or CI check."
+          "notes": "Use commitlint with husky or pre-commit for enforcing Conventional Commits and add a CI check to keep version/changelog automation deterministic.",
+          "verification": "Test that non-conforming commit messages are rejected by the configured hooks and CI check.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json",
+            ".cz.toml"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -319,7 +354,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -360,6 +395,83 @@
           "optionalFiles": ["deny.toml"],
           "anyOfFiles": ["Cargo.lock"],
           "pinningNotes": "Required for binaries/services; optional for libraries (add to .gitignore for libs). See https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control"
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": ["cargo build --locked"],
+          "exampleConfigFiles": ["Cargo.lock", "rust-toolchain.toml"],
+          "notes": "Commit Cargo.lock for binaries/services and pin Rust versions with rust-toolchain.toml. Use --locked in CI.",
+          "verification": "Cargo.lock is present and CI uses --locked. Rust toolchain is pinned.",
+          "requiredFiles": ["Cargo.lock"],
+          "optionalFiles": ["rust-toolchain.toml"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          },
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "cargo-cyclonedx",
+            "syft",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for crates and container artifacts, enable secret scanning, and sign tags/commits for critical repos.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for build/test/release stages to standardize across Rust repos.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["azure-devops"],
@@ -201,7 +201,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -210,14 +210,43 @@
         "stack": {
           "exampleTools": ["semantic-release", "standard-version"],
           "exampleConfigFiles": [".releaserc", "package.json", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to automatically bump package.json version, generate/update CHANGELOG.md, create git tags, and publish release artifacts. Protect release branches and ensure release tooling only runs there.",
-          "verification": "Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries."
+          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Keep package.json (or a VERSION file) as the single canonical version source and have CI publish npm/GitHub/Docker artifacts from that same version. Protect release branches and ensure release tooling only runs there.",
+          "verification": "Check that the canonical version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it generates the expected next version, updates package.json or VERSION, and creates/updates CHANGELOG.md with commit-based entries.",
+          "requiredFiles": ["package.json"],
+          "optionalFiles": ["VERSION", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "semantic-release",
+            "changesets",
+            "npm publish",
+            "docker buildx"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Release workflow must publish npm packages, GitHub releases, and Docker images from the same canonical version (package.json or VERSION). Avoid separate manual steps or ad-hoc scripts for different artifacts.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md", "VERSION"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -229,8 +258,15 @@
             "@commitlint/config-conventional"
           ],
           "exampleConfigFiles": ["commitlint.config.*"],
-          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.",
-          "verification": "Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen)."
+          "notes": "Enforce Conventional Commits via commit-msg hooks (e.g., Husky) and a CI job so versioning/changelog automation is deterministic.",
+          "verification": "Create a test commit using the documented convention and ensure the commit message passes both local commit-msg hooks and CI checks.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -315,7 +351,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -324,8 +360,8 @@
         "stack": {
           "exampleTools": ["TypeScript compiler (tsc)"],
           "exampleConfigFiles": ["tsconfig.json"],
-          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.",
-          "verification": "Presence of tsconfig.json indicates type-checking is configured for the repository.",
+          "notes": "Adopt a TypeScript-first policy. Require tsconfig.json with strict mode enabled ('strict': true) and enforce `npm run typecheck` (or equivalent) in CI. For legacy JS, allow JSDoc + `checkJs` or staged migration with `allowJs` while incrementally increasing coverage.",
+          "verification": "tsconfig.json exists with strict mode enabled and CI runs the typecheck script; legacy JS modules use JSDoc/checkJs or allowJs as an explicit migration path.",
           "requiredFiles": ["tsconfig.json"],
           "requiredScripts": ["typecheck"],
           "bazelHints": {
@@ -353,6 +389,82 @@
           "notes": "Require a lockfile for reproducible installs and pin Node.js/tooling versions; block merges on new high-severity vulnerabilities.",
           "verification": "Dependency lockfile is present; security scanning is configured in CI or project tooling.",
           "optionalFiles": ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "npm ci",
+            "pnpm install --frozen-lockfile",
+            "yarn --immutable"
+          ],
+          "exampleConfigFiles": [
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock"
+          ],
+          "notes": "Require a lockfile and pinned Node/tool versions (.nvmrc or .tool-versions). Pin base images in Dockerfiles and avoid non-deterministic install flags.",
+          "verification": "Lockfile is present and CI uses a frozen/immutable install. Dockerfiles reference pinned base images.",
+          "anyOfFiles": ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"],
+          "optionalFiles": [".nvmrc", ".tool-versions"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "syft",
+            "cyclonedx-npm",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for npm and container artifacts, enable secret scanning, and sign tags/commits for protected branches.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for lint/test/build/release stages and keep repo-specific overrides minimal.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["github-actions"],
@@ -201,7 +201,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "github-actions": {
             "job": "release"
@@ -210,14 +210,43 @@
         "stack": {
           "exampleTools": ["semantic-release", "standard-version"],
           "exampleConfigFiles": [".releaserc", "package.json", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to automatically bump package.json version, generate/update CHANGELOG.md, create git tags, and publish release artifacts. Protect release branches and ensure release tooling only runs there.",
-          "verification": "Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries."
+          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Keep package.json (or a VERSION file) as the single canonical version source and have CI publish npm/GitHub/Docker artifacts from that same version. Protect release branches and ensure release tooling only runs there.",
+          "verification": "Check that the canonical version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it generates the expected next version, updates package.json or VERSION, and creates/updates CHANGELOG.md with commit-based entries.",
+          "requiredFiles": ["package.json"],
+          "optionalFiles": ["VERSION", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "semantic-release",
+            "changesets",
+            "npm publish",
+            "docker buildx"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Release workflow must publish npm packages, GitHub releases, and Docker images from the same canonical version (package.json or VERSION). Avoid separate manual steps or ad-hoc scripts for different artifacts.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md", "VERSION"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -229,8 +258,15 @@
             "@commitlint/config-conventional"
           ],
           "exampleConfigFiles": ["commitlint.config.*"],
-          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.",
-          "verification": "Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen)."
+          "notes": "Enforce Conventional Commits via commit-msg hooks (e.g., Husky) and a CI job so versioning/changelog automation is deterministic.",
+          "verification": "Create a test commit using the documented convention and ensure the commit message passes both local commit-msg hooks and CI checks.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -315,7 +351,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -324,8 +360,8 @@
         "stack": {
           "exampleTools": ["TypeScript compiler (tsc)"],
           "exampleConfigFiles": ["tsconfig.json"],
-          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.",
-          "verification": "Presence of tsconfig.json indicates type-checking is configured for the repository.",
+          "notes": "Adopt a TypeScript-first policy. Require tsconfig.json with strict mode enabled ('strict': true) and enforce `npm run typecheck` (or equivalent) in CI. For legacy JS, allow JSDoc + `checkJs` or staged migration with `allowJs` while incrementally increasing coverage.",
+          "verification": "tsconfig.json exists with strict mode enabled and CI runs the typecheck script; legacy JS modules use JSDoc/checkJs or allowJs as an explicit migration path.",
           "requiredFiles": ["tsconfig.json"],
           "requiredScripts": ["typecheck"],
           "bazelHints": {
@@ -353,6 +389,82 @@
           "notes": "Require a lockfile for reproducible installs and pin Node.js/tooling versions; block merges on new high-severity vulnerabilities.",
           "verification": "Dependency lockfile is present; security scanning is configured in CI or project tooling.",
           "optionalFiles": ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "npm ci",
+            "pnpm install --frozen-lockfile",
+            "yarn --immutable"
+          ],
+          "exampleConfigFiles": [
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock"
+          ],
+          "notes": "Require a lockfile and pinned Node/tool versions (.nvmrc or .tool-versions). Pin base images in Dockerfiles and avoid non-deterministic install flags.",
+          "verification": "Lockfile is present and CI uses a frozen/immutable install. Dockerfiles reference pinned base images.",
+          "anyOfFiles": ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"],
+          "optionalFiles": [".nvmrc", ".tool-versions"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "syft",
+            "cyclonedx-npm",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for npm and container artifacts, enable secret scanning, and sign tags/commits for protected branches.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for lint/test/build/release stages and keep repo-specific overrides minimal.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "stack": "typescript-js",
   "stackLabel": "TypeScript / JavaScript",
   "ciSystems": ["azure-devops", "github-actions"],
@@ -213,7 +213,7 @@
       {
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
-        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.",
+        "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "ciHints": {
           "azure-devops": {
             "stage": "release"
@@ -225,14 +225,46 @@
         "stack": {
           "exampleTools": ["semantic-release", "standard-version"],
           "exampleConfigFiles": [".releaserc", "package.json", "CHANGELOG.md"],
-          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Configure CI to automatically bump package.json version, generate/update CHANGELOG.md, create git tags, and publish release artifacts. Protect release branches and ensure release tooling only runs there.",
-          "verification": "Check that the version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it automatically generates the expected next version, updates package.json, and creates/updates CHANGELOG.md with commit-based entries."
+          "notes": "Automate version bumping and changelog generation from Conventional Commits using semantic-release or standard-version. Keep package.json (or a VERSION file) as the single canonical version source and have CI publish npm/GitHub/Docker artifacts from that same version. Protect release branches and ensure release tooling only runs there.",
+          "verification": "Check that the canonical version field follows SemVer, and trigger the configured release workflow (for example, a dry run of semantic-release or standard-version) to confirm it generates the expected next version, updates package.json or VERSION, and creates/updates CHANGELOG.md with commit-based entries.",
+          "requiredFiles": ["package.json"],
+          "optionalFiles": ["VERSION", "CHANGELOG.md"],
+          "requiredScripts": ["release"]
+        }
+      },
+      {
+        "id": "unified-release-workflow",
+        "label": "Unified Release Workflow",
+        "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "release"
+          },
+          "github-actions": {
+            "job": "release"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "semantic-release",
+            "changesets",
+            "npm publish",
+            "docker buildx"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/release.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Release workflow must publish npm packages, GitHub releases, and Docker images from the same canonical version (package.json or VERSION). Avoid separate manual steps or ad-hoc scripts for different artifacts.",
+          "verification": "Trigger the release pipeline and confirm all artifacts share the same version number and tag.",
+          "requiredScripts": ["release"],
+          "optionalFiles": ["CHANGELOG.md", "VERSION"]
         }
       },
       {
         "id": "commit-linting",
         "label": "Commit Linting",
-        "description": "Enforce structured commit messages such as Conventional Commits.",
+        "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -247,8 +279,15 @@
             "@commitlint/config-conventional"
           ],
           "exampleConfigFiles": ["commitlint.config.*"],
-          "notes": "Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.",
-          "verification": "Create a test commit using the documented convention and ensure the commit message passes the configured commit linting or wizard (for example, commitlint or commitizen)."
+          "notes": "Enforce Conventional Commits via commit-msg hooks (e.g., Husky) and a CI job so versioning/changelog automation is deterministic.",
+          "verification": "Create a test commit using the documented convention and ensure the commit message passes both local commit-msg hooks and CI checks.",
+          "anyOfFiles": [
+            "commitlint.config.js",
+            "commitlint.config.cjs",
+            "commitlint.config.mjs",
+            "commitlint.config.json"
+          ],
+          "requiredScripts": ["commitlint"]
         }
       },
       {
@@ -345,7 +384,7 @@
       {
         "id": "type-checking",
         "label": "Type Checking",
-        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code.",
+        "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -357,8 +396,8 @@
         "stack": {
           "exampleTools": ["TypeScript compiler (tsc)"],
           "exampleConfigFiles": ["tsconfig.json"],
-          "notes": "Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.",
-          "verification": "Presence of tsconfig.json indicates type-checking is configured for the repository.",
+          "notes": "Adopt a TypeScript-first policy. Require tsconfig.json with strict mode enabled ('strict': true) and enforce `npm run typecheck` (or equivalent) in CI. For legacy JS, allow JSDoc + `checkJs` or staged migration with `allowJs` while incrementally increasing coverage.",
+          "verification": "tsconfig.json exists with strict mode enabled and CI runs the typecheck script; legacy JS modules use JSDoc/checkJs or allowJs as an explicit migration path.",
           "requiredFiles": ["tsconfig.json"],
           "requiredScripts": ["typecheck"],
           "bazelHints": {
@@ -389,6 +428,91 @@
           "notes": "Require a lockfile for reproducible installs and pin Node.js/tooling versions; block merges on new high-severity vulnerabilities.",
           "verification": "Dependency lockfile is present; security scanning is configured in CI or project tooling.",
           "optionalFiles": ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"]
+        }
+      },
+      {
+        "id": "deterministic-builds",
+        "label": "Deterministic & Hermetic Builds",
+        "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "build"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "npm ci",
+            "pnpm install --frozen-lockfile",
+            "yarn --immutable"
+          ],
+          "exampleConfigFiles": [
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock"
+          ],
+          "notes": "Require a lockfile and pinned Node/tool versions (.nvmrc or .tool-versions). Pin base images in Dockerfiles and avoid non-deterministic install flags.",
+          "verification": "Lockfile is present and CI uses a frozen/immutable install. Dockerfiles reference pinned base images.",
+          "anyOfFiles": ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"],
+          "optionalFiles": [".nvmrc", ".tool-versions"]
+        }
+      },
+      {
+        "id": "provenance-security",
+        "label": "Provenance & Security Metadata",
+        "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "security"
+          },
+          "github-actions": {
+            "job": "security"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "syft",
+            "cyclonedx-npm",
+            "codeql",
+            "gitleaks",
+            "cosign"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/codeql.yml",
+            ".github/workflows/provenance.yml"
+          ],
+          "notes": "Generate SBOM/provenance for npm and container artifacts, enable secret scanning, and sign tags/commits for protected branches.",
+          "verification": "SBOM/provenance artifacts are published alongside releases, and CI runs secret/code scanning.",
+          "optionalFiles": ["SECURITY.md", ".github/workflows/codeql.yml"]
+        }
+      },
+      {
+        "id": "ci-templates-automation",
+        "label": "CI Templates & Automation",
+        "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
+        "ciHints": {
+          "azure-devops": {
+            "stage": "ci"
+          },
+          "github-actions": {
+            "job": "ci"
+          }
+        },
+        "stack": {
+          "exampleTools": [
+            "GitHub Actions reusable workflows",
+            "Azure DevOps templates"
+          ],
+          "exampleConfigFiles": [
+            ".github/workflows/ci.yml",
+            "azure-pipelines.yml"
+          ],
+          "notes": "Use shared CI templates for lint/test/build/release stages and keep repo-specific overrides minimal.",
+          "verification": "CI pipeline references a shared template or reusable workflow and follows the standard job naming.",
+          "anyOfFiles": [".github/workflows/ci.yml", "azure-pipelines.yml"],
+          "requiredScripts": ["ci"]
         }
       },
       {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vitest": "^4.0.15"
   },
   "engines": {
-    "node": ">=20 <21"
+    "node": ">=22 <23"
   },
   "lint-staged": {
     "*.{js,ts,mjs,json,md}": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,13 @@ import type {
   StackId,
   CiSystem,
 } from "./types.js";
+import { STANDARDS_VERSION, STANDARDS_SCHEMA_VERSION } from "./version.js";
 
 // Re-export types for consumers
 export type { MasterJson, StackChecklistJson, StackId, CiSystem };
+
+// Re-export version info (stable API contract)
+export { STANDARDS_VERSION, STANDARDS_SCHEMA_VERSION };
 
 // ESM equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -50,6 +54,27 @@ export function listSupportedStacks(): readonly StackId[] {
 export function listSupportedCiSystems(): readonly CiSystem[] {
   const spec = loadMasterSpec();
   return spec.ciSystems as CiSystem[];
+}
+
+/**
+ * PUBLIC API CONTRACT (semver-governed)
+ * Alias for loadBaseline - loads stack-specific standards checklist.
+ * Breaking changes to this function signature require a major version bump.
+ */
+export function getStandards(
+  stack: StackId,
+  ci?: CiSystem,
+): StackChecklistJson {
+  return loadBaseline(stack, ci);
+}
+
+/**
+ * PUBLIC API CONTRACT (semver-governed)
+ * Alias for loadMasterSpec - loads the master standards schema.
+ * Breaking changes to this function signature require a major version bump.
+ */
+export function getSchema(): MasterJson {
+  return loadMasterSpec();
 }
 
 /** Optional CLI entry point for debugging */

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,11 @@
+/**
+ * AUTO-GENERATED at build time by scripts/build.ts
+ * DO NOT EDIT MANUALLY
+ *
+ * This module provides version information for the repo-standards package.
+ * Consumers should import from here instead of package.json to avoid
+ * ESM/CJS interop issues.
+ */
+
+export const STANDARDS_VERSION = "3.1.0";
+export const STANDARDS_SCHEMA_VERSION = 3;


### PR DESCRIPTION
BREAKING CHANGE: Node engine changed from >=20 <21 to >=22 <23

- Add src/version.ts with exported STANDARDS_VERSION (avoids package.json imports)
- Add getStandards() and getSchema() as semver-governed public API
- Update scripts/build.ts to generate version.ts at build time
- Engine now requires Node 22 LTS for reproducibility across all repos