### PR TITLE
Relax engine rules for Node version compatibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,13 @@ We love your input! We want to make contributing to this project as easy and tra
 - Proposing new features
 - Becoming a maintainer
 
+## Development Environment
+
+This repository uses Node.js. The `.nvmrc` file specifies Node 22 for contributors to ensure consistent development environments, but **this is not a constraint on consumers**.
+
+- **Contributors**: Use `nvm use` to switch to the recommended Node version
+- **Consumers**: The package supports Node 22 and above (see `engines` in package.json)
+
 ## We Use [Github Flow](https://guides.github.com/introduction/flow/index.html), So All Code Changes Happen Through Pull Requests
 
 Pull requests are the best way to propose changes to the codebase (we use [Github Flow](https://guides.github.com/introduction/flow/index.html)). We actively welcome your pull requests:

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -599,7 +599,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -599,7 +599,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "github-actions": {
             "job": "ci"

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -676,7 +676,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -595,7 +595,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -595,7 +595,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "github-actions": {
             "job": "ci"

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -672,7 +672,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"

--- a/config/standards.json
+++ b/config/standards.json
@@ -1909,7 +1909,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "executionStage": "pre-commit",
         "appliesTo": {
           "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
@@ -1926,8 +1926,8 @@
           "typescript-js": {
             "exampleTools": [],
             "exampleConfigFiles": ["package.json"],
-            "notes": "Specify the 'engines' field in package.json to define the required Node.js version (e.g., \"engines\": { \"node\": \">=18.0.0\" }). This helps prevent environment-related bugs and ensures all developers use compatible Node.js versions.",
-            "verification": "package.json must contain an 'engines' field specifying the required Node.js version.",
+            "notes": "Specify the 'engines' field in package.json with a minimum version appropriate for your application (e.g., \"engines\": { \"node\": \">=20\" }). Use open-ended constraints (>=) to avoid blocking consumers from upgrading. Only use upper bounds (<) when there are known incompatibilities.",
+            "verification": "package.json must contain an 'engines' field specifying the minimum required Node.js version.",
             "requiredFiles": ["package.json"]
           },
           "csharp-dotnet": {
@@ -1944,7 +1944,7 @@
               "setup.py",
               ".python-version"
             ],
-            "notes": "Specify python_requires in pyproject.toml (e.g., requires-python = \">=3.9\") or setup.py (e.g., python_requires='>=3.9'). Consider adding .python-version for pyenv users to automatically switch to the correct Python version.",
+            "notes": "Specify requires-python in pyproject.toml with a minimum version appropriate for your application (e.g., requires-python = \">=3.9\"). Use open-ended constraints to avoid blocking consumers from upgrading. The .python-version file is for local development convenience only.",
             "verification": "pyproject.toml or setup.py must specify python_requires; .python-version is recommended for local development.",
             "requiredFiles": ["pyproject.toml"],
             "optionalFiles": [".python-version"]

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -615,7 +615,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -628,7 +628,7 @@
             "setup.py",
             ".python-version"
           ],
-          "notes": "Specify python_requires in pyproject.toml (e.g., requires-python = \">=3.9\") or setup.py (e.g., python_requires='>=3.9'). Consider adding .python-version for pyenv users to automatically switch to the correct Python version.",
+          "notes": "Specify requires-python in pyproject.toml with a minimum version appropriate for your application (e.g., requires-python = \">=3.9\"). Use open-ended constraints to avoid blocking consumers from upgrading. The .python-version file is for local development convenience only.",
           "verification": "pyproject.toml or setup.py must specify python_requires; .python-version is recommended for local development.",
           "requiredFiles": ["pyproject.toml"],
           "optionalFiles": [".python-version"]

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -615,7 +615,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -628,7 +628,7 @@
             "setup.py",
             ".python-version"
           ],
-          "notes": "Specify python_requires in pyproject.toml (e.g., requires-python = \">=3.9\") or setup.py (e.g., python_requires='>=3.9'). Consider adding .python-version for pyenv users to automatically switch to the correct Python version.",
+          "notes": "Specify requires-python in pyproject.toml with a minimum version appropriate for your application (e.g., requires-python = \">=3.9\"). Use open-ended constraints to avoid blocking consumers from upgrading. The .python-version file is for local development convenience only.",
           "verification": "pyproject.toml or setup.py must specify python_requires; .python-version is recommended for local development.",
           "requiredFiles": ["pyproject.toml"],
           "optionalFiles": [".python-version"]

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -692,7 +692,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -708,7 +708,7 @@
             "setup.py",
             ".python-version"
           ],
-          "notes": "Specify python_requires in pyproject.toml (e.g., requires-python = \">=3.9\") or setup.py (e.g., python_requires='>=3.9'). Consider adding .python-version for pyenv users to automatically switch to the correct Python version.",
+          "notes": "Specify requires-python in pyproject.toml with a minimum version appropriate for your application (e.g., requires-python = \">=3.9\"). Use open-ended constraints to avoid blocking consumers from upgrading. The .python-version file is for local development convenience only.",
           "verification": "pyproject.toml or setup.py must specify python_requires; .python-version is recommended for local development.",
           "requiredFiles": ["pyproject.toml"],
           "optionalFiles": [".python-version"]

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -597,7 +597,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -597,7 +597,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "github-actions": {
             "job": "ci"

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -674,7 +674,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -650,7 +650,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -659,8 +659,8 @@
         "stack": {
           "exampleTools": [],
           "exampleConfigFiles": ["package.json"],
-          "notes": "Specify the 'engines' field in package.json to define the required Node.js version (e.g., \"engines\": { \"node\": \">=18.0.0\" }). This helps prevent environment-related bugs and ensures all developers use compatible Node.js versions.",
-          "verification": "package.json must contain an 'engines' field specifying the required Node.js version.",
+          "notes": "Specify the 'engines' field in package.json with a minimum version appropriate for your application (e.g., \"engines\": { \"node\": \">=20\" }). Use open-ended constraints (>=) to avoid blocking consumers from upgrading. Only use upper bounds (<) when there are known incompatibilities.",
+          "verification": "package.json must contain an 'engines' field specifying the minimum required Node.js version.",
           "requiredFiles": ["package.json"]
         }
       },

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -650,7 +650,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "github-actions": {
             "job": "ci"
@@ -659,8 +659,8 @@
         "stack": {
           "exampleTools": [],
           "exampleConfigFiles": ["package.json"],
-          "notes": "Specify the 'engines' field in package.json to define the required Node.js version (e.g., \"engines\": { \"node\": \">=18.0.0\" }). This helps prevent environment-related bugs and ensures all developers use compatible Node.js versions.",
-          "verification": "package.json must contain an 'engines' field specifying the required Node.js version.",
+          "notes": "Specify the 'engines' field in package.json with a minimum version appropriate for your application (e.g., \"engines\": { \"node\": \">=20\" }). Use open-ended constraints (>=) to avoid blocking consumers from upgrading. Only use upper bounds (<) when there are known incompatibilities.",
+          "verification": "package.json must contain an 'engines' field specifying the minimum required Node.js version.",
           "requiredFiles": ["package.json"]
         }
       },

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -727,7 +727,7 @@
       {
         "id": "runtime-version",
         "label": "Runtime Version Specification",
-        "description": "Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.",
+        "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "ciHints": {
           "azure-devops": {
             "stage": "quality"
@@ -739,8 +739,8 @@
         "stack": {
           "exampleTools": [],
           "exampleConfigFiles": ["package.json"],
-          "notes": "Specify the 'engines' field in package.json to define the required Node.js version (e.g., \"engines\": { \"node\": \">=18.0.0\" }). This helps prevent environment-related bugs and ensures all developers use compatible Node.js versions.",
-          "verification": "package.json must contain an 'engines' field specifying the required Node.js version.",
+          "notes": "Specify the 'engines' field in package.json with a minimum version appropriate for your application (e.g., \"engines\": { \"node\": \">=20\" }). Use open-ended constraints (>=) to avoid blocking consumers from upgrading. Only use upper bounds (<) when there are known incompatibilities.",
+          "verification": "package.json must contain an 'engines' field specifying the minimum required Node.js version.",
           "requiredFiles": ["package.json"]
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "vitest": "^4.0.15"
       },
       "engines": {
-        "node": ">=22 <23"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^4.0.15"
   },
   "engines": {
-    "node": ">=22 <23"
+    "node": ">=22"
   },
   "lint-staged": {
     "*.{js,cjs,ts,mjs,json,md}": [

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,5 +7,5 @@
  * ESM/CJS interop issues.
  */
 
-export const STANDARDS_VERSION = "5.1.0";
+export const STANDARDS_VERSION = "5.2.0";
 export const STANDARDS_SCHEMA_VERSION = 5;


### PR DESCRIPTION
- Change engines from ">=22 <23" to ">=22" to allow Node 24+
- Update runtime-version guidance to emphasize app-appropriate versioning
- Recommend open-ended constraints (>=) over strict ranges
- Add Development Environment section to CONTRIBUTING.md clarifying that .nvmrc is for contributors, not a consumer constraint

This addresses downstream consumer complaints about being forced to pin old Node versions when upgrading their dependencies.