### PR TITLE
feat!: add core.safecrlf=warn to Windows contributor guidance

### DIFF
--- a/TO-DO.md
+++ b/TO-DO.md
@@ -12,7 +12,7 @@ PHASE ONE:
 
 5. **After adding/changing `.gitattributes`, do a one-time “renormalize” commit.** This converts existing tracked files to the policy so you don’t keep landmines around and re-trigger failures later.
 
-6. **Windows contributors: disable surprise conversions in Git.** Prefer `core.autocrlf=false` with `.gitattributes` as the repo truth; this reduces “it worked locally but not in CI” churn. ([Git SCM][4])
+6. **Windows contributors: disable surprise conversions in Git.** Set `core.autocrlf=false` and `core.safecrlf=warn`. The first setting lets `.gitattributes` be the repo truth; the second prevents fatal errors when files are normalized (Git installers sometimes set `safecrlf=true`, which blocks normalization entirely). This reduces "it worked locally but not in CI" churn. ([Git SCM][4])
 
 ---
 

--- a/config/standards.json
+++ b/config/standards.json
@@ -170,7 +170,7 @@
           "typescript-js": {
             "exampleTools": ["git"],
             "exampleConfigFiles": [".gitattributes", ".editorconfig"],
-            "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false.",
+            "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false and core.safecrlf=warn (safecrlf=true blocks normalization with fatal errors).",
             "verification": "Run 'git ls-files --eol' and verify no unexpected CRLF in LF-only files.",
             "requiredFiles": [".gitattributes"],
             "optionalFiles": [".editorconfig"],

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -139,7 +139,7 @@
         "stack": {
           "exampleTools": ["git"],
           "exampleConfigFiles": [".gitattributes", ".editorconfig"],
-          "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false.",
+          "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false and core.safecrlf=warn (safecrlf=true blocks normalization with fatal errors).",
           "verification": "Run 'git ls-files --eol' and verify no unexpected CRLF in LF-only files.",
           "requiredFiles": [".gitattributes"],
           "optionalFiles": [".editorconfig"],

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -139,7 +139,7 @@
         "stack": {
           "exampleTools": ["git"],
           "exampleConfigFiles": [".gitattributes", ".editorconfig"],
-          "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false.",
+          "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false and core.safecrlf=warn (safecrlf=true blocks normalization with fatal errors).",
           "verification": "Run 'git ls-files --eol' and verify no unexpected CRLF in LF-only files.",
           "requiredFiles": [".gitattributes"],
           "optionalFiles": [".editorconfig"],

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -143,7 +143,7 @@
         "stack": {
           "exampleTools": ["git"],
           "exampleConfigFiles": [".gitattributes", ".editorconfig"],
-          "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false.",
+          "notes": "Use .gitattributes as the authority for EOL; .editorconfig is supplementary for editor display. Mark *.sh, *.bash as eol=lf. After adding .gitattributes, run 'git add --renormalize .' to fix existing files. Windows contributors should set core.autocrlf=false and core.safecrlf=warn (safecrlf=true blocks normalization with fatal errors).",
           "verification": "Run 'git ls-files --eol' and verify no unexpected CRLF in LF-only files.",
           "requiredFiles": [".gitattributes"],
           "optionalFiles": [".editorconfig"],

--- a/templates/gitattributes.base
+++ b/templates/gitattributes.base
@@ -7,7 +7,12 @@
 #   git add --renormalize .
 #   git commit -m "chore: normalize line endings"
 #
-# Windows contributors should set: git config --global core.autocrlf false
+# Windows contributors should set:
+#   git config --global core.autocrlf false
+#   git config --global core.safecrlf warn
+#
+# Note: core.safecrlf=true (sometimes set by Git installers) causes fatal errors
+# when .gitattributes normalizes CRLF to LF. Use 'warn' to allow normalization.
 
 # Default: Auto-detect text files and normalize to LF on commit
 * text=auto eol=lf

--- a/templates/gitattributes.csharp-dotnet
+++ b/templates/gitattributes.csharp-dotnet
@@ -4,6 +4,13 @@
 # After adding this file, run:
 #   git add --renormalize .
 #   git commit -m "chore: normalize line endings"
+#
+# Windows contributors should set:
+#   git config --global core.autocrlf false
+#   git config --global core.safecrlf warn
+#
+# Note: core.safecrlf=true (sometimes set by Git installers) causes fatal errors
+# when .gitattributes normalizes CRLF to LF. Use 'warn' to allow normalization.
 
 # Default: Auto-detect text files and normalize to LF on commit
 * text=auto eol=lf

--- a/templates/gitattributes.go
+++ b/templates/gitattributes.go
@@ -4,6 +4,13 @@
 # After adding this file, run:
 #   git add --renormalize .
 #   git commit -m "chore: normalize line endings"
+#
+# Windows contributors should set:
+#   git config --global core.autocrlf false
+#   git config --global core.safecrlf warn
+#
+# Note: core.safecrlf=true (sometimes set by Git installers) causes fatal errors
+# when .gitattributes normalizes CRLF to LF. Use 'warn' to allow normalization.
 
 # Default: Auto-detect text files and normalize to LF on commit
 * text=auto eol=lf

--- a/templates/gitattributes.python
+++ b/templates/gitattributes.python
@@ -4,6 +4,13 @@
 # After adding this file, run:
 #   git add --renormalize .
 #   git commit -m "chore: normalize line endings"
+#
+# Windows contributors should set:
+#   git config --global core.autocrlf false
+#   git config --global core.safecrlf warn
+#
+# Note: core.safecrlf=true (sometimes set by Git installers) causes fatal errors
+# when .gitattributes normalizes CRLF to LF. Use 'warn' to allow normalization.
 
 # Default: Auto-detect text files and normalize to LF on commit
 * text=auto eol=lf

--- a/templates/gitattributes.rust
+++ b/templates/gitattributes.rust
@@ -4,6 +4,13 @@
 # After adding this file, run:
 #   git add --renormalize .
 #   git commit -m "chore: normalize line endings"
+#
+# Windows contributors should set:
+#   git config --global core.autocrlf false
+#   git config --global core.safecrlf warn
+#
+# Note: core.safecrlf=true (sometimes set by Git installers) causes fatal errors
+# when .gitattributes normalizes CRLF to LF. Use 'warn' to allow normalization.
 
 # Default: Auto-detect text files and normalize to LF on commit
 * text=auto eol=lf

--- a/templates/gitattributes.typescript-js
+++ b/templates/gitattributes.typescript-js
@@ -4,6 +4,13 @@
 # After adding this file, run:
 #   git add --renormalize .
 #   git commit -m "chore: normalize line endings"
+#
+# Windows contributors should set:
+#   git config --global core.autocrlf false
+#   git config --global core.safecrlf warn
+#
+# Note: core.safecrlf=true (sometimes set by Git installers) causes fatal errors
+# when .gitattributes normalizes CRLF to LF. Use 'warn' to allow normalization.
 
 # Default: Auto-detect text files and normalize to LF on commit
 * text=auto eol=lf


### PR DESCRIPTION
Windows contributors with core.safecrlf=true (sometimes set by Git installers) experience fatal errors when .gitattributes normalizes CRLF to LF. This blocks them from committing entirely.

Updated guidance in all .gitattributes templates and documentation to recommend both core.autocrlf=false AND core.safecrlf=warn.

BREAKING CHANGE: Consumers should update their Windows contributor onboarding to include `git config --global core.safecrlf warn` in addition to the existing autocrlf guidance. Existing repos may need to communicate this change to Windows contributors experiencing normalization failures.