### PR TITLE
feat: pattern migration P1 + P2.1 (catalog + persistence templates)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,16 @@ out/
 *.tsbuildinfo.*
 
 # -----------------------------------------------------
+# Python (pattern templates ship Python reference impls)
+# -----------------------------------------------------
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# -----------------------------------------------------
 # Docker / Containers
 # -----------------------------------------------------
 # Local docker layers, build artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,9 @@ Desktop.ini
 *.swp
 *.swo
 
+# Claude Code local state
+.claude/
+
 # JetBrains IDEs (WebStorm, IntelliJ)
 *.iml
 *.ipr

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -126,6 +130,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -157,6 +162,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -182,6 +188,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "GitVersion.yml",
@@ -216,6 +223,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -245,6 +253,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".editorconfig"
@@ -266,6 +275,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "azure-pipelines.yml",
@@ -297,6 +307,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "azure-pipelines.yml",
@@ -318,6 +329,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -350,6 +362,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -377,6 +390,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -403,6 +417,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -430,6 +445,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "lefthook.yml",
@@ -453,6 +469,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -476,6 +493,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml"
@@ -497,6 +515,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -531,6 +550,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "packages.lock.json",
@@ -555,6 +575,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "packages.lock.json",
@@ -580,6 +601,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -608,6 +630,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -637,6 +660,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.csproj",
@@ -659,6 +683,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -687,6 +712,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -715,6 +741,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -739,6 +766,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -760,6 +788,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".editorconfig"
@@ -771,6 +800,12 @@
           "notes": "Use .editorconfig file globs to exclude generated code from analysis. Document exclusions with comments.",
           "verification": "Review .editorconfig and confirm exclusions are explicit and documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -783,6 +818,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "appsettings.json"
@@ -804,6 +840,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -825,6 +862,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -849,6 +887,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -878,6 +917,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "NsDepCop.config.nsdepcop",
@@ -903,6 +943,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.IntegrationTests.csproj"
@@ -925,6 +966,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.csproj"
@@ -945,6 +987,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "sonar-project.properties"
@@ -966,6 +1009,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -986,6 +1030,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.verified.txt",
@@ -1009,6 +1054,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.schema.json",
@@ -1033,6 +1079,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "TestData/",
@@ -1056,6 +1103,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Tests/AiSafety/"
@@ -1078,6 +1126,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "AiProvenance.cs"
@@ -1100,6 +1149,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1111,6 +1161,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -806,6 +806,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1241,6 +1265,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -898,6 +898,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.csharp-dotnet.azure-devops.json
+++ b/config/standards.csharp-dotnet.azure-devops.json
@@ -1319,7 +1319,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1328,7 +1328,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1337,7 +1337,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1346,7 +1346,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1355,7 +1355,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -126,6 +130,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -157,6 +162,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -182,6 +188,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "GitVersion.yml",
@@ -216,6 +223,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -245,6 +253,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".editorconfig"
@@ -266,6 +275,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "azure-pipelines.yml",
@@ -297,6 +307,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "azure-pipelines.yml",
@@ -318,6 +329,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -350,6 +362,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -377,6 +390,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -403,6 +417,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -430,6 +445,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "lefthook.yml",
@@ -453,6 +469,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -476,6 +493,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml"
@@ -497,6 +515,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -531,6 +550,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "packages.lock.json",
@@ -555,6 +575,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "packages.lock.json",
@@ -580,6 +601,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -608,6 +630,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -637,6 +660,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.csproj",
@@ -659,6 +683,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -687,6 +712,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -715,6 +741,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -739,6 +766,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -760,6 +788,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".editorconfig"
@@ -771,6 +800,12 @@
           "notes": "Use .editorconfig file globs to exclude generated code from analysis. Document exclusions with comments.",
           "verification": "Review .editorconfig and confirm exclusions are explicit and documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -783,6 +818,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "appsettings.json"
@@ -804,6 +840,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -825,6 +862,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -849,6 +887,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -878,6 +917,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "NsDepCop.config.nsdepcop",
@@ -903,6 +943,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.IntegrationTests.csproj"
@@ -925,6 +966,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.csproj"
@@ -945,6 +987,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "sonar-project.properties"
@@ -966,6 +1009,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -986,6 +1030,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.verified.txt",
@@ -1009,6 +1054,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.schema.json",
@@ -1033,6 +1079,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "TestData/",
@@ -1056,6 +1103,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Tests/AiSafety/"
@@ -1078,6 +1126,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "AiProvenance.cs"
@@ -1100,6 +1149,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1111,6 +1161,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -806,6 +806,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1241,6 +1265,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -898,6 +898,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.csharp-dotnet.github-actions.json
+++ b/config/standards.csharp-dotnet.github-actions.json
@@ -1319,7 +1319,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1328,7 +1328,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1337,7 +1337,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1346,7 +1346,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1355,7 +1355,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -15,6 +15,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -52,6 +53,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -79,6 +81,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -106,6 +109,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -143,6 +147,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -177,6 +182,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -205,6 +211,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "GitVersion.yml",
@@ -243,6 +250,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -276,6 +284,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".editorconfig"
@@ -300,6 +309,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "azure-pipelines.yml",
@@ -335,6 +345,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "azure-pipelines.yml",
@@ -359,6 +370,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -394,6 +406,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -424,6 +437,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -453,6 +467,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -484,6 +499,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "lefthook.yml",
@@ -511,6 +527,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -538,6 +555,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml"
@@ -562,6 +580,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -599,6 +618,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "packages.lock.json",
@@ -626,6 +646,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "packages.lock.json",
@@ -654,6 +675,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -685,6 +707,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -717,6 +740,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.csproj",
@@ -742,6 +766,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -773,6 +798,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -805,6 +831,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -833,6 +860,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -858,6 +886,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".editorconfig"
@@ -869,6 +898,12 @@
           "notes": "Use .editorconfig file globs to exclude generated code from analysis. Document exclusions with comments.",
           "verification": "Review .editorconfig and confirm exclusions are explicit and documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -884,6 +919,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "appsettings.json"
@@ -908,6 +944,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -932,6 +969,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -960,6 +998,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -993,6 +1032,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "NsDepCop.config.nsdepcop",
@@ -1021,6 +1061,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.IntegrationTests.csproj"
@@ -1046,6 +1087,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.csproj"
@@ -1069,6 +1111,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "sonar-project.properties"
@@ -1093,6 +1136,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1117,6 +1161,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.verified.txt",
@@ -1144,6 +1189,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*.schema.json",
@@ -1172,6 +1218,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "TestData/",
@@ -1199,6 +1246,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Tests/AiSafety/"
@@ -1225,6 +1273,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "AiProvenance.cs"
@@ -1251,6 +1300,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1262,6 +1312,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -904,6 +904,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1392,6 +1416,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -1005,6 +1005,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.csharp-dotnet.json
+++ b/config/standards.csharp-dotnet.json
@@ -1470,7 +1470,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1479,7 +1479,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1488,7 +1488,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1497,7 +1497,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1506,7 +1506,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -801,6 +801,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1224,6 +1248,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -1302,7 +1302,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1311,7 +1311,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1320,7 +1320,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1329,7 +1329,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1338,7 +1338,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -127,6 +131,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -157,6 +162,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -182,6 +188,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".goreleaser.yml",
@@ -212,6 +219,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -239,6 +247,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -260,6 +269,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -290,6 +300,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".goreleaser.yml",
@@ -311,6 +322,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -343,6 +355,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -370,6 +383,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -396,6 +410,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -422,6 +437,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml",
@@ -445,6 +461,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -468,6 +485,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -490,6 +508,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -520,6 +539,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.sum"
@@ -544,6 +564,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.sum",
@@ -573,6 +594,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -602,6 +624,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -631,6 +654,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.mod",
@@ -656,6 +680,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -684,6 +709,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -712,6 +738,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -735,6 +762,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -756,6 +784,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -766,6 +795,12 @@
           "notes": "Define skip-dirs and skip-files in .golangci.yml. Use //nolint comments sparingly and always include justification (//nolint:errcheck // reason).",
           "verification": "Review .golangci.yml and confirm skip paths are explicit and documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -778,6 +813,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -798,6 +834,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -819,6 +856,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -843,6 +881,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -871,6 +910,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -890,6 +930,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*_test.go"
@@ -910,6 +951,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*_test.go"
@@ -931,6 +973,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -952,6 +995,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -972,6 +1016,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "testdata/golden/",
@@ -995,6 +1040,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "schemas/"
@@ -1017,6 +1063,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "testdata/"
@@ -1039,6 +1086,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai_safety_test.go"
@@ -1061,6 +1109,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai/provenance.go"
@@ -1083,6 +1132,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1094,6 +1144,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.go.azure-devops.json
+++ b/config/standards.go.azure-devops.json
@@ -892,6 +892,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -801,6 +801,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1224,6 +1248,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -1302,7 +1302,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1311,7 +1311,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1320,7 +1320,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1329,7 +1329,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1338,7 +1338,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -127,6 +131,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -157,6 +162,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -182,6 +188,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".goreleaser.yml",
@@ -212,6 +219,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -239,6 +247,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -260,6 +269,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -290,6 +300,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".goreleaser.yml",
@@ -311,6 +322,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -343,6 +355,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -370,6 +383,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -396,6 +410,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -422,6 +437,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml",
@@ -445,6 +461,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -468,6 +485,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -490,6 +508,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -520,6 +539,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.sum"
@@ -544,6 +564,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.sum",
@@ -573,6 +594,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -602,6 +624,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -631,6 +654,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.mod",
@@ -656,6 +680,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -684,6 +709,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -712,6 +738,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -735,6 +762,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -756,6 +784,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -766,6 +795,12 @@
           "notes": "Define skip-dirs and skip-files in .golangci.yml. Use //nolint comments sparingly and always include justification (//nolint:errcheck // reason).",
           "verification": "Review .golangci.yml and confirm skip paths are explicit and documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -778,6 +813,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -798,6 +834,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -819,6 +856,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -843,6 +881,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -871,6 +910,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -890,6 +930,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*_test.go"
@@ -910,6 +951,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*_test.go"
@@ -931,6 +973,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -952,6 +995,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -972,6 +1016,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "testdata/golden/",
@@ -995,6 +1040,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "schemas/"
@@ -1017,6 +1063,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "testdata/"
@@ -1039,6 +1086,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai_safety_test.go"
@@ -1061,6 +1109,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai/provenance.go"
@@ -1083,6 +1132,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1094,6 +1144,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.go.github-actions.json
+++ b/config/standards.go.github-actions.json
@@ -892,6 +892,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -999,6 +999,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -899,6 +899,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1375,6 +1399,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -1453,7 +1453,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1462,7 +1462,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1471,7 +1471,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1480,7 +1480,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1489,7 +1489,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.go.json
+++ b/config/standards.go.json
@@ -15,6 +15,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -52,6 +53,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -79,6 +81,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -106,6 +109,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -144,6 +148,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -177,6 +182,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -205,6 +211,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".goreleaser.yml",
@@ -239,6 +246,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -270,6 +278,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -294,6 +303,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -328,6 +338,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".goreleaser.yml",
@@ -352,6 +363,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -387,6 +399,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -417,6 +430,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -446,6 +460,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -476,6 +491,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml",
@@ -503,6 +519,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -530,6 +547,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -555,6 +573,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -588,6 +607,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.sum"
@@ -615,6 +635,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.sum",
@@ -647,6 +668,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -679,6 +701,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -711,6 +734,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "go.mod",
@@ -739,6 +763,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -770,6 +795,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -802,6 +828,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -829,6 +856,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -854,6 +882,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -864,6 +893,12 @@
           "notes": "Define skip-dirs and skip-files in .golangci.yml. Use //nolint comments sparingly and always include justification (//nolint:errcheck // reason).",
           "verification": "Review .golangci.yml and confirm skip paths are explicit and documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -879,6 +914,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -902,6 +938,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -926,6 +963,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -954,6 +992,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -986,6 +1025,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1008,6 +1048,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*_test.go"
@@ -1031,6 +1072,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "*_test.go"
@@ -1055,6 +1097,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".golangci.yml"
@@ -1079,6 +1122,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1103,6 +1147,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "testdata/golden/",
@@ -1130,6 +1175,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "schemas/"
@@ -1156,6 +1202,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "testdata/"
@@ -1182,6 +1229,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai_safety_test.go"
@@ -1208,6 +1256,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai/provenance.go"
@@ -1234,6 +1283,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1245,6 +1295,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.json
+++ b/config/standards.json
@@ -3566,6 +3566,224 @@
         "enforcement": "optional",
         "severity": "info",
         "maturity": "documented"
+      },
+      {
+        "id": "qg-split-ts-configs",
+        "label": "Split TypeScript Configs",
+        "description": "Separate tsconfig files for typecheck (strict, bundler resolution), build (emit, CommonJS or ESM as appropriate), tests, and type-tests. A guard test locks module/moduleResolution per config so tsc cannot silently overwrite an IIFE bundle with a CommonJS one, or vice versa.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js"]
+        }
+      },
+      {
+        "id": "qg-no-any-types",
+        "label": "No any / Any Types",
+        "description": "CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "python"]
+        }
+      },
+      {
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-partial-branch-ratchet",
+        "label": "LCOV Partial-Branch Ratchet",
+        "description": "LCOV partial-branches baseline with a locked-zero files list. CI fails if a file on the locked-zero list develops any partial branches. Catches a class of untested conditional branches that line and statement coverage alone do not detect.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js"]
+        }
+      },
+      {
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "sec-subprocess-allowlist",
+        "label": "Subprocess Command Allowlist",
+        "description": "Commit an allowlist file (e.g., .subprocess-allowlist.json) enumerating repo-owned non-literal subprocess commands. A guardrail script verifies every subprocess call is either a string literal or appears in the allowlist. Compensates for globally-disabled subprocess-safety lint rules.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["python"]
+        }
+      },
+      {
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "maturity": "documented",
+        "conditions": ["has-cli"],
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "maturity": "documented",
+        "conditions": ["has-cli"],
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "maturity": "documented",
+        "enforcement": "optional",
+        "severity": "info",
+        "executionStage": "pre-commit",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
       }
     ]
   }

--- a/config/standards.json
+++ b/config/standards.json
@@ -3203,7 +3203,7 @@
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
-        "maturity": "documented",
+        "maturity": "template-available",
         "conditions": ["has-database"],
         "executionStage": "ci-pr",
         "appliesTo": {
@@ -3216,7 +3216,7 @@
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
-        "maturity": "documented",
+        "maturity": "template-available",
         "conditions": ["has-database"],
         "executionStage": "ci-pr",
         "appliesTo": {
@@ -3229,7 +3229,7 @@
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
-        "maturity": "documented",
+        "maturity": "template-available",
         "conditions": ["has-database"],
         "executionStage": "ci-pr",
         "appliesTo": {
@@ -3242,7 +3242,7 @@
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
-        "maturity": "documented",
+        "maturity": "template-available",
         "conditions": ["has-database"],
         "executionStage": "ci-pr",
         "appliesTo": {
@@ -3255,7 +3255,7 @@
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
-        "maturity": "documented",
+        "maturity": "template-available",
         "conditions": ["has-database"],
         "executionStage": "ci-pr",
         "appliesTo": {

--- a/config/standards.json
+++ b/config/standards.json
@@ -232,7 +232,8 @@
               "description": "Verify no CRLF in shell scripts"
             }
           }
-        }
+        },
+        "maturity": "documented"
       },
       {
         "id": "crlf-detection",
@@ -310,7 +311,8 @@
               "description": "Detect CRLF in shell scripts"
             }
           }
-        }
+        },
+        "maturity": "documented"
       },
       {
         "id": "gitignore-and-dockerignore",
@@ -366,7 +368,8 @@
             "requiredFiles": [".gitignore"],
             "optionalFiles": [".dockerignore"]
           }
-        }
+        },
+        "maturity": "documented"
       },
       {
         "id": "linting",
@@ -481,7 +484,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "unit-test-runner",
@@ -565,7 +569,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "containerization",
@@ -626,7 +631,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "semantic-versioning",
@@ -707,7 +713,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "version-guard",
@@ -787,7 +794,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "release-artifact-exclusion",
@@ -841,7 +849,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "unified-release-workflow",
@@ -927,7 +936,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "release-hook-bypass",
@@ -991,7 +1001,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "commit-linting",
@@ -1084,7 +1095,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "unit-test-reporter",
@@ -1155,7 +1167,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "ci-quality-gates",
@@ -1241,7 +1254,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "code-formatter",
@@ -1320,7 +1334,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "pre-commit-hooks",
@@ -1378,7 +1393,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "hook-ci-parity",
@@ -1432,7 +1448,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "secret-scanning-precommit",
@@ -1489,7 +1506,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "type-checking",
@@ -1576,7 +1594,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "dependency-security",
@@ -1646,7 +1665,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "deterministic-builds",
@@ -1718,7 +1738,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "provenance-security",
@@ -1813,7 +1834,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "ci-templates-automation",
@@ -1904,7 +1926,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "runtime-version",
@@ -1966,7 +1989,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "documentation",
@@ -2027,7 +2051,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "repository-governance",
@@ -2108,7 +2133,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "canonical-verify",
@@ -2162,7 +2188,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "config-authority",
@@ -2233,7 +2260,8 @@
           }
         },
         "enforcement": "required",
-        "severity": "error"
+        "severity": "error",
+        "maturity": "documented"
       },
       {
         "id": "explicit-skip-paths",
@@ -2288,6 +2316,19 @@
             "notes": "Define skip-dirs and skip-files in .golangci.yml. Use //nolint comments sparingly and always include justification (//nolint:errcheck // reason).",
             "verification": "Review .golangci.yml and confirm skip paths are explicit and documented."
           }
+        },
+        "enforcement": "required",
+        "severity": "error",
+        "maturity": "documented"
+      },
+      {
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "maturity": "documented",
+        "executionStage": "pre-push",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
         },
         "enforcement": "required",
         "severity": "error"
@@ -2375,7 +2416,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "dependency-architecture-rules",
@@ -2445,7 +2487,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "integration-testing",
@@ -2496,7 +2539,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "performance-baselining",
@@ -2547,7 +2591,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "complexity-analysis",
@@ -2598,7 +2643,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "accessibility-auditing",
@@ -2649,7 +2695,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "ai-drift-detection",
@@ -2702,7 +2749,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "ai-schema-enforcement",
@@ -2759,7 +2807,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "ai-golden-tests",
@@ -2812,7 +2861,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "ai-safety-checks",
@@ -2865,7 +2915,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "ai-provenance-tracking",
@@ -2918,7 +2969,8 @@
           }
         },
         "enforcement": "recommended",
-        "severity": "warn"
+        "severity": "warn",
+        "maturity": "documented"
       },
       {
         "id": "agent-invariants",
@@ -2974,6 +3026,144 @@
             "verification": "INVARIANTS.md exists with machine-readable verification commands.",
             "requiredFiles": ["INVARIANTS.md"]
           }
+        },
+        "enforcement": "recommended",
+        "severity": "warn",
+        "maturity": "documented"
+      },
+      {
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "maturity": "documented",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "maturity": "documented",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "maturity": "documented",
+        "executionStage": "pre-push",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "maturity": "documented",
+        "executionStage": "pre-push",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "maturity": "documented",
+        "executionStage": "pre-push",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "maturity": "documented",
+        "executionStage": "pre-commit",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "maturity": "documented",
+        "conditions": ["has-database"],
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "maturity": "documented",
+        "conditions": ["has-database"],
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "maturity": "documented",
+        "conditions": ["has-database"],
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "maturity": "documented",
+        "conditions": ["has-database"],
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        },
+        "enforcement": "recommended",
+        "severity": "warn"
+      },
+      {
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "maturity": "documented",
+        "conditions": ["has-database"],
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
         },
         "enforcement": "recommended",
         "severity": "warn"
@@ -3032,7 +3222,8 @@
           }
         },
         "enforcement": "optional",
-        "severity": "info"
+        "severity": "info",
+        "maturity": "documented"
       },
       {
         "id": "agent-phase-gates",
@@ -3088,7 +3279,8 @@
           }
         },
         "enforcement": "optional",
-        "severity": "info"
+        "severity": "info",
+        "maturity": "documented"
       },
       {
         "id": "agent-victory-gates",
@@ -3144,7 +3336,8 @@
           }
         },
         "enforcement": "optional",
-        "severity": "info"
+        "severity": "info",
+        "maturity": "documented"
       }
     ]
   }

--- a/config/standards.json
+++ b/config/standards.json
@@ -2332,6 +2332,102 @@
         },
         "enforcement": "required",
         "severity": "error"
+      },
+      {
+        "id": "ci-package-manager-exclusivity",
+        "label": "Package Manager Exclusivity",
+        "description": "Enforce a single package manager per repo via a preinstall script that exits non-zero if the wrong one is invoked. Combined with engine-strict, prevents lockfile drift and npm/pnpm mixed installs that break reproducibility.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "pre-commit",
+        "appliesTo": {
+          "stacks": ["typescript-js"]
+        }
+      },
+      {
+        "id": "ci-lockfile-discipline",
+        "label": "Lockfile Discipline",
+        "description": "CI gate fails on the presence of any unauthorized lockfile — e.g., a package-lock.json in a pnpm repo, or a yarn.lock in an npm repo. Companion to package-manager exclusivity; catches wrong-tool installs that slip past the preinstall guard.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js"]
+        }
+      },
+      {
+        "id": "de-packagemanager-field",
+        "label": "packageManager Field",
+        "description": "package.json declares a pinned `packageManager` field (e.g., \"pnpm@9.15.0\") that Corepack and CI can use to auto-select the correct tool + version. Keeps the package-manager exclusivity guard and engine pins aligned with one authoritative source.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js"]
+        }
+      },
+      {
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "pre-commit",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "de-engine-strict",
+        "label": "engine-strict Enforcement",
+        "description": "Set engine-strict=true in .npmrc (or equivalent) so the engines field in package.json becomes a hard install-time constraint, not advisory. Prevents 'works on my machine' drift from mismatched Node or package-manager versions.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "pre-commit",
+        "appliesTo": {
+          "stacks": ["typescript-js"]
+        }
+      },
+      {
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "pre-push",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "maturity": "documented",
+        "enforcement": "required",
+        "severity": "error",
+        "executionStage": "release",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
       }
     ],
     "recommended": [
@@ -3167,6 +3263,138 @@
         },
         "enforcement": "recommended",
         "severity": "warn"
+      },
+      {
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "pre-push",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "ci-package-manager-command-guard",
+        "label": "Package-Manager Command Guard",
+        "description": "CI gate scans workflows, scripts, and configs for forbidden package-manager commands — e.g., 'npm install' or 'npm ci' in a pnpm-exclusive repo. Catches drift that the preinstall guard alone won't: workflow-file edits that bypass installs entirely.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js"]
+        }
+      },
+      {
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
+      },
+      {
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "maturity": "documented",
+        "enforcement": "recommended",
+        "severity": "warn",
+        "executionStage": "ci-pr",
+        "appliesTo": {
+          "stacks": ["typescript-js", "csharp-dotnet", "python", "rust", "go"]
+        }
       }
     ],
     "optionalEnhancements": [

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -841,6 +841,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1278,6 +1302,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -934,6 +934,108 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.",
+        "id": "qg-no-any-types",
+        "label": "No any / Any Types",
+        "maturity": "documented"
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit an allowlist file (e.g., .subprocess-allowlist.json) enumerating repo-owned non-literal subprocess commands. A guardrail script verifies every subprocess call is either a string literal or appears in the allowlist. Compensates for globally-disabled subprocess-safety lint rules.",
+        "id": "sec-subprocess-allowlist",
+        "label": "Subprocess Command Allowlist",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "pyproject.toml",
@@ -129,6 +133,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -161,6 +166,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -186,6 +192,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -221,6 +228,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -253,6 +261,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml"
@@ -275,6 +284,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -307,6 +317,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -328,6 +339,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".cz.toml",
@@ -359,6 +371,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -388,6 +401,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -414,6 +428,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -441,6 +456,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml"
@@ -462,6 +478,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -487,6 +504,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml",
@@ -509,6 +527,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -546,6 +565,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "requirements.txt",
@@ -574,6 +594,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "requirements.txt",
@@ -607,6 +628,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -636,6 +658,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -665,6 +688,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -691,6 +715,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -720,6 +745,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -748,6 +774,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -773,6 +800,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -794,6 +822,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml"
@@ -806,6 +835,12 @@
           "notes": "Define exclude patterns in pyproject.toml [tool.ruff], [tool.black], [tool.mypy] sections. Document why each path is excluded. Avoid runtime --exclude flags.",
           "verification": "Review pyproject.toml and confirm all exclusions are defined there, not in scripts."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -818,6 +853,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "logging configuration files",
@@ -840,6 +876,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -861,6 +898,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -885,6 +923,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -914,6 +953,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -940,6 +980,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/integration/"
@@ -960,6 +1001,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pytest.ini",
@@ -982,6 +1024,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "radon.cfg"
@@ -1002,6 +1045,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1021,6 +1065,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_baselines/",
@@ -1045,6 +1090,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "schemas/",
@@ -1069,6 +1115,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/fixtures/",
@@ -1092,6 +1139,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_safety/"
@@ -1114,6 +1162,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai/provenance.py"
@@ -1137,6 +1186,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1148,6 +1198,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.python.azure-devops.json
+++ b/config/standards.python.azure-devops.json
@@ -1368,7 +1368,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1377,7 +1377,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1386,7 +1386,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1395,7 +1395,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1404,7 +1404,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -841,6 +841,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1278,6 +1302,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -934,6 +934,108 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.",
+        "id": "qg-no-any-types",
+        "label": "No any / Any Types",
+        "maturity": "documented"
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit an allowlist file (e.g., .subprocess-allowlist.json) enumerating repo-owned non-literal subprocess commands. A guardrail script verifies every subprocess call is either a string literal or appears in the allowlist. Compensates for globally-disabled subprocess-safety lint rules.",
+        "id": "sec-subprocess-allowlist",
+        "label": "Subprocess Command Allowlist",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "pyproject.toml",
@@ -129,6 +133,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -161,6 +166,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -186,6 +192,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -221,6 +228,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -253,6 +261,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml"
@@ -275,6 +284,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -307,6 +317,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -328,6 +339,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".cz.toml",
@@ -359,6 +371,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -388,6 +401,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -414,6 +428,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -441,6 +456,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml"
@@ -462,6 +478,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -487,6 +504,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml",
@@ -509,6 +527,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -546,6 +565,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "requirements.txt",
@@ -574,6 +594,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "requirements.txt",
@@ -607,6 +628,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -636,6 +658,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -665,6 +688,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -691,6 +715,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -720,6 +745,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -748,6 +774,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -773,6 +800,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -794,6 +822,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml"
@@ -806,6 +835,12 @@
           "notes": "Define exclude patterns in pyproject.toml [tool.ruff], [tool.black], [tool.mypy] sections. Document why each path is excluded. Avoid runtime --exclude flags.",
           "verification": "Review pyproject.toml and confirm all exclusions are defined there, not in scripts."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -818,6 +853,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "logging configuration files",
@@ -840,6 +876,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -861,6 +898,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -885,6 +923,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -914,6 +953,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -940,6 +980,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/integration/"
@@ -960,6 +1001,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pytest.ini",
@@ -982,6 +1024,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "radon.cfg"
@@ -1002,6 +1045,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1021,6 +1065,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_baselines/",
@@ -1045,6 +1090,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "schemas/",
@@ -1069,6 +1115,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/fixtures/",
@@ -1092,6 +1139,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_safety/"
@@ -1114,6 +1162,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai/provenance.py"
@@ -1137,6 +1186,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1148,6 +1198,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.python.github-actions.json
+++ b/config/standards.python.github-actions.json
@@ -1368,7 +1368,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1377,7 +1377,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1386,7 +1386,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1395,7 +1395,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1404,7 +1404,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -15,6 +15,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -52,6 +53,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -79,6 +81,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -106,6 +109,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "pyproject.toml",
@@ -146,6 +150,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -181,6 +186,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -209,6 +215,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -248,6 +255,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -284,6 +292,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml"
@@ -309,6 +318,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -345,6 +355,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -369,6 +380,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".cz.toml",
@@ -403,6 +415,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -435,6 +448,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -464,6 +478,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -495,6 +510,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml"
@@ -520,6 +536,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -549,6 +566,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml",
@@ -574,6 +592,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -614,6 +633,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "requirements.txt",
@@ -645,6 +665,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "requirements.txt",
@@ -681,6 +702,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -713,6 +735,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -745,6 +768,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -774,6 +798,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -806,6 +831,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -838,6 +864,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -867,6 +894,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -892,6 +920,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml"
@@ -904,6 +933,12 @@
           "notes": "Define exclude patterns in pyproject.toml [tool.ruff], [tool.black], [tool.mypy] sections. Document why each path is excluded. Avoid runtime --exclude flags.",
           "verification": "Review pyproject.toml and confirm all exclusions are defined there, not in scripts."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -919,6 +954,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "logging configuration files",
@@ -944,6 +980,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -968,6 +1005,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -996,6 +1034,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -1029,6 +1068,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pyproject.toml",
@@ -1058,6 +1098,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/integration/"
@@ -1081,6 +1122,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "pytest.ini",
@@ -1106,6 +1148,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "radon.cfg"
@@ -1129,6 +1172,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1152,6 +1196,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_baselines/",
@@ -1180,6 +1225,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "schemas/",
@@ -1208,6 +1254,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/fixtures/",
@@ -1235,6 +1282,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_safety/"
@@ -1261,6 +1309,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "ai/provenance.py"
@@ -1288,6 +1337,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1299,6 +1349,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -1519,7 +1519,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1528,7 +1528,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1537,7 +1537,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1546,7 +1546,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1555,7 +1555,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -939,6 +939,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1429,6 +1453,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.python.json
+++ b/config/standards.python.json
@@ -1041,6 +1041,108 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.",
+        "id": "qg-no-any-types",
+        "label": "No any / Any Types",
+        "maturity": "documented"
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit an allowlist file (e.g., .subprocess-allowlist.json) enumerating repo-owned non-literal subprocess commands. A guardrail script verifies every subprocess call is either a string literal or appears in the allowlist. Compensates for globally-disabled subprocess-safety lint rules.",
+        "id": "sec-subprocess-allowlist",
+        "label": "Subprocess Command Allowlist",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -811,6 +811,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1237,6 +1261,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -127,6 +131,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -159,6 +164,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -184,6 +190,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Cargo.toml",
@@ -216,6 +223,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -244,6 +252,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rustfmt.toml"
@@ -265,6 +274,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -295,6 +305,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -315,6 +326,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -347,6 +359,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -375,6 +388,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -401,6 +415,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -429,6 +444,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml"
@@ -451,6 +467,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -474,6 +491,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -495,6 +513,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -524,6 +543,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "Cargo.lock"
@@ -553,6 +573,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Cargo.lock",
@@ -580,6 +601,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -609,6 +631,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -638,6 +661,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rust-toolchain.toml",
@@ -661,6 +685,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -690,6 +715,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -718,6 +744,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -742,6 +769,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -764,6 +792,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rustfmt.toml",
@@ -776,6 +805,12 @@
           "notes": "Use #[rustfmt::skip] or #[allow(clippy::*)] sparingly and document why. For directory-level exclusions, use Cargo.toml workspace exclude.",
           "verification": "Search for skip annotations and confirm each is documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -788,6 +823,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -807,6 +843,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -828,6 +865,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -852,6 +890,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -880,6 +919,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "deny.toml"
@@ -903,6 +943,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/"
@@ -923,6 +964,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "benches/"
@@ -944,6 +986,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "clippy.toml"
@@ -965,6 +1008,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -985,6 +1029,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "snapshots/",
@@ -1008,6 +1053,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/schemas/"
@@ -1031,6 +1077,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "snapshots/"
@@ -1052,6 +1099,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_safety/"
@@ -1074,6 +1122,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/ai/provenance.rs"
@@ -1096,6 +1145,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1107,6 +1157,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -901,6 +901,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.rust.azure-devops.json
+++ b/config/standards.rust.azure-devops.json
@@ -1315,7 +1315,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1324,7 +1324,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1333,7 +1333,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1342,7 +1342,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1351,7 +1351,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -811,6 +811,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1237,6 +1261,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -127,6 +131,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -159,6 +164,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -184,6 +190,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Cargo.toml",
@@ -216,6 +223,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -244,6 +252,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rustfmt.toml"
@@ -265,6 +274,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -295,6 +305,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -315,6 +326,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -347,6 +359,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -375,6 +388,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -401,6 +415,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -429,6 +444,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml"
@@ -451,6 +467,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -474,6 +491,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -495,6 +513,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -524,6 +543,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "Cargo.lock"
@@ -553,6 +573,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Cargo.lock",
@@ -580,6 +601,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -609,6 +631,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -638,6 +661,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rust-toolchain.toml",
@@ -661,6 +685,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -690,6 +715,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -718,6 +744,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -742,6 +769,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -764,6 +792,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rustfmt.toml",
@@ -776,6 +805,12 @@
           "notes": "Use #[rustfmt::skip] or #[allow(clippy::*)] sparingly and document why. For directory-level exclusions, use Cargo.toml workspace exclude.",
           "verification": "Search for skip annotations and confirm each is documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -788,6 +823,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -807,6 +843,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -828,6 +865,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -852,6 +890,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -880,6 +919,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "deny.toml"
@@ -903,6 +943,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/"
@@ -923,6 +964,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "benches/"
@@ -944,6 +986,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "clippy.toml"
@@ -965,6 +1008,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -985,6 +1029,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "snapshots/",
@@ -1008,6 +1053,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/schemas/"
@@ -1031,6 +1077,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "snapshots/"
@@ -1052,6 +1099,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_safety/"
@@ -1074,6 +1122,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/ai/provenance.rs"
@@ -1096,6 +1145,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1107,6 +1157,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -901,6 +901,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.rust.github-actions.json
+++ b/config/standards.rust.github-actions.json
@@ -1315,7 +1315,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1324,7 +1324,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1333,7 +1333,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1342,7 +1342,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1351,7 +1351,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -1008,6 +1008,96 @@
           ],
           "verification": "victory-gates.md exists with milestone criteria."
         }
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -909,6 +909,30 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1388,6 +1412,66 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -1466,7 +1466,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1475,7 +1475,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1484,7 +1484,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1493,7 +1493,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1502,7 +1502,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.rust.json
+++ b/config/standards.rust.json
@@ -15,6 +15,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -52,6 +53,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -79,6 +81,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -106,6 +109,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -144,6 +148,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -179,6 +184,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -207,6 +213,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Cargo.toml",
@@ -243,6 +250,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -275,6 +283,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rustfmt.toml"
@@ -299,6 +308,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -333,6 +343,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -356,6 +367,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -391,6 +403,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -422,6 +435,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -451,6 +465,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -483,6 +498,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".pre-commit-config.yaml"
@@ -509,6 +525,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -536,6 +553,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -560,6 +578,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -592,6 +611,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "Cargo.lock"
@@ -624,6 +644,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Cargo.lock",
@@ -654,6 +675,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -686,6 +708,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -718,6 +741,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rust-toolchain.toml",
@@ -744,6 +768,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -776,6 +801,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -808,6 +834,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Makefile",
@@ -836,6 +863,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -862,6 +890,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "rustfmt.toml",
@@ -874,6 +903,12 @@
           "notes": "Use #[rustfmt::skip] or #[allow(clippy::*)] sparingly and document why. For directory-level exclusions, use Cargo.toml workspace exclude.",
           "verification": "Search for skip annotations and confirm each is documented."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -889,6 +924,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -911,6 +947,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -935,6 +972,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -963,6 +1001,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -995,6 +1034,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "deny.toml"
@@ -1021,6 +1061,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/"
@@ -1044,6 +1085,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "benches/"
@@ -1068,6 +1110,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "clippy.toml"
@@ -1092,6 +1135,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1116,6 +1160,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "snapshots/",
@@ -1143,6 +1188,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/schemas/"
@@ -1170,6 +1216,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "snapshots/"
@@ -1195,6 +1242,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai_safety/"
@@ -1221,6 +1269,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/ai/provenance.rs"
@@ -1247,6 +1296,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1258,6 +1308,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.schema.json
+++ b/config/standards.schema.json
@@ -62,6 +62,11 @@
       "enum": ["error", "warn", "info"],
       "description": "Severity level for violations."
     },
+    "Maturity": {
+      "type": "string",
+      "enum": ["documented", "template-planned", "template-available"],
+      "description": "Implementation maturity of a checklist item. 'documented' = described only; 'template-planned' = template scheduled; 'template-available' = template exists under templates/patterns/<id>/."
+    },
     "Meta": {
       "type": "object",
       "additionalProperties": false,
@@ -282,7 +287,14 @@
     "ChecklistItem": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "label", "description", "appliesTo", "executionStage"],
+      "required": [
+        "id",
+        "label",
+        "description",
+        "maturity",
+        "appliesTo",
+        "executionStage"
+      ],
       "properties": {
         "id": {
           "type": "string",
@@ -294,6 +306,16 @@
         },
         "description": {
           "type": "string"
+        },
+        "maturity": {
+          "$ref": "#/$defs/Maturity"
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Condition predicates (e.g., 'has-database', 'has-cli') that gate applicability. If any condition is unmet, the item evaluates as N/A in verify output."
         },
         "enforcement": {
           "$ref": "#/$defs/Enforcement",

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -855,6 +855,54 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Enforce a single package manager per repo via a preinstall script that exits non-zero if the wrong one is invoked. Combined with engine-strict, prevents lockfile drift and npm/pnpm mixed installs that break reproducibility.",
+        "id": "ci-package-manager-exclusivity",
+        "label": "Package Manager Exclusivity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails on the presence of any unauthorized lockfile — e.g., a package-lock.json in a pnpm repo, or a yarn.lock in an npm repo. Companion to package-manager exclusivity; catches wrong-tool installs that slip past the preinstall guard.",
+        "id": "ci-lockfile-discipline",
+        "label": "Lockfile Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "package.json declares a pinned `packageManager` field (e.g., \"pnpm@9.15.0\") that Corepack and CI can use to auto-select the correct tool + version. Keeps the package-manager exclusivity guard and engine pins aligned with one authoritative source.",
+        "id": "de-packagemanager-field",
+        "label": "packageManager Field",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Set engine-strict=true in .npmrc (or equivalent) so the engines field in package.json becomes a hard install-time constraint, not advisory. Prevents 'works on my machine' drift from mismatched Node or package-manager versions.",
+        "id": "de-engine-strict",
+        "label": "engine-strict Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1297,6 +1345,72 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate scans workflows, scripts, and configs for forbidden package-manager commands — e.g., 'npm install' or 'npm ci' in a pnpm-exclusive repo. Catches drift that the preinstall guard alone won't: workflow-file edits that bypass installs entirely.",
+        "id": "ci-package-manager-command-guard",
+        "label": "Package-Manager Command Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "eslint.config.js",
@@ -142,6 +146,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -177,6 +182,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -202,6 +208,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".releaserc",
@@ -236,6 +243,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -266,6 +274,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".prettierignore",
@@ -291,6 +300,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -323,6 +333,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -349,6 +360,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -379,6 +391,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -406,6 +419,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -432,6 +446,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -461,6 +476,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".husky/",
@@ -485,6 +501,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -509,6 +526,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -532,6 +550,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -564,6 +583,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package-lock.json",
@@ -592,6 +612,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "package-lock.json",
@@ -625,6 +646,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -654,6 +676,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -683,6 +706,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -704,6 +728,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -733,6 +758,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -761,6 +787,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -785,6 +812,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -807,6 +835,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".eslintignore",
@@ -820,6 +849,12 @@
           "notes": "Define ignores in eslint.config.js (ignores array) and .prettierignore. Document why each path is excluded (generated code, vendor, etc.). Avoid ad-hoc --ignore-path flags in scripts.",
           "verification": "Review ignore configs and confirm all exclusions are documented and intentional."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -832,6 +867,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -851,6 +887,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -872,6 +909,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -896,6 +934,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -927,6 +966,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".dependency-cruiser.cjs",
@@ -956,6 +996,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "jest.config.*",
@@ -979,6 +1020,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "lighthouserc.json"
@@ -1000,6 +1042,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".eslintrc.*",
@@ -1022,6 +1065,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1042,6 +1086,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "__snapshots__/",
@@ -1065,6 +1110,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/schemas/",
@@ -1089,6 +1135,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "__fixtures__/ai-outputs/",
@@ -1112,6 +1159,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai-safety/"
@@ -1134,6 +1182,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/ai/provenance.ts"
@@ -1156,6 +1205,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1167,6 +1217,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands for all critical repository rules."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -1417,7 +1417,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1426,7 +1426,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1435,7 +1435,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1444,7 +1444,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1453,7 +1453,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.typescript-js.azure-devops.json
+++ b/config/standards.typescript-js.azure-devops.json
@@ -969,6 +969,114 @@
           ],
           "verification": "victory-gates.md exists with milestone completion criteria and evidence requirements."
         }
+      },
+      {
+        "description": "Separate tsconfig files for typecheck (strict, bundler resolution), build (emit, CommonJS or ESM as appropriate), tests, and type-tests. A guard test locks module/moduleResolution per config so tsc cannot silently overwrite an IIFE bundle with a CommonJS one, or vice versa.",
+        "id": "qg-split-ts-configs",
+        "label": "Split TypeScript Configs",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.",
+        "id": "qg-no-any-types",
+        "label": "No any / Any Types",
+        "maturity": "documented"
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "LCOV partial-branches baseline with a locked-zero files list. CI fails if a file on the locked-zero list develops any partial branches. Catches a class of untested conditional branches that line and statement coverage alone do not detect.",
+        "id": "td-partial-branch-ratchet",
+        "label": "LCOV Partial-Branch Ratchet",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -855,6 +855,54 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Enforce a single package manager per repo via a preinstall script that exits non-zero if the wrong one is invoked. Combined with engine-strict, prevents lockfile drift and npm/pnpm mixed installs that break reproducibility.",
+        "id": "ci-package-manager-exclusivity",
+        "label": "Package Manager Exclusivity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails on the presence of any unauthorized lockfile — e.g., a package-lock.json in a pnpm repo, or a yarn.lock in an npm repo. Companion to package-manager exclusivity; catches wrong-tool installs that slip past the preinstall guard.",
+        "id": "ci-lockfile-discipline",
+        "label": "Lockfile Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "package.json declares a pinned `packageManager` field (e.g., \"pnpm@9.15.0\") that Corepack and CI can use to auto-select the correct tool + version. Keeps the package-manager exclusivity guard and engine pins aligned with one authoritative source.",
+        "id": "de-packagemanager-field",
+        "label": "packageManager Field",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Set engine-strict=true in .npmrc (or equivalent) so the engines field in package.json becomes a hard install-time constraint, not advisory. Prevents 'works on my machine' drift from mismatched Node or package-manager versions.",
+        "id": "de-engine-strict",
+        "label": "engine-strict Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1297,6 +1345,72 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate scans workflows, scripts, and configs for forbidden package-manager commands — e.g., 'npm install' or 'npm ci' in a pnpm-exclusive repo. Catches drift that the preinstall guard alone won't: workflow-file edits that bypass installs entirely.",
+        "id": "ci-package-manager-command-guard",
+        "label": "Package-Manager Command Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -11,6 +11,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -44,6 +45,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -68,6 +70,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -92,6 +95,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "eslint.config.js",
@@ -142,6 +146,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -177,6 +182,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -202,6 +208,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".releaserc",
@@ -236,6 +243,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -266,6 +274,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".prettierignore",
@@ -291,6 +300,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -323,6 +333,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -349,6 +360,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -379,6 +391,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -406,6 +419,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -432,6 +446,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -461,6 +476,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".husky/",
@@ -485,6 +501,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -509,6 +526,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -532,6 +550,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -564,6 +583,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package-lock.json",
@@ -592,6 +612,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "package-lock.json",
@@ -625,6 +646,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -654,6 +676,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -683,6 +706,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -704,6 +728,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -733,6 +758,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -761,6 +787,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -785,6 +812,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -807,6 +835,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".eslintignore",
@@ -820,6 +849,12 @@
           "notes": "Define ignores in eslint.config.js (ignores array) and .prettierignore. Document why each path is excluded (generated code, vendor, etc.). Avoid ad-hoc --ignore-path flags in scripts.",
           "verification": "Review ignore configs and confirm all exclusions are documented and intentional."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -832,6 +867,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -851,6 +887,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -872,6 +909,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -896,6 +934,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -927,6 +966,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".dependency-cruiser.cjs",
@@ -956,6 +996,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "jest.config.*",
@@ -979,6 +1020,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "lighthouserc.json"
@@ -1000,6 +1042,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".eslintrc.*",
@@ -1022,6 +1065,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1042,6 +1086,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "__snapshots__/",
@@ -1065,6 +1110,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/schemas/",
@@ -1089,6 +1135,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "__fixtures__/ai-outputs/",
@@ -1112,6 +1159,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai-safety/"
@@ -1134,6 +1182,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/ai/provenance.ts"
@@ -1156,6 +1205,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1167,6 +1217,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands for all critical repository rules."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -1417,7 +1417,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1426,7 +1426,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1435,7 +1435,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1444,7 +1444,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1453,7 +1453,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.typescript-js.github-actions.json
+++ b/config/standards.typescript-js.github-actions.json
@@ -969,6 +969,114 @@
           ],
           "verification": "victory-gates.md exists with milestone completion criteria and evidence requirements."
         }
+      },
+      {
+        "description": "Separate tsconfig files for typecheck (strict, bundler resolution), build (emit, CommonJS or ESM as appropriate), tests, and type-tests. A guard test locks module/moduleResolution per config so tsc cannot silently overwrite an IIFE bundle with a CommonJS one, or vice versa.",
+        "id": "qg-split-ts-configs",
+        "label": "Split TypeScript Configs",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.",
+        "id": "qg-no-any-types",
+        "label": "No any / Any Types",
+        "maturity": "documented"
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "LCOV partial-branches baseline with a locked-zero files list. CI fails if a file on the locked-zero list develops any partial branches. Catches a class of untested conditional branches that line and statement coverage alone do not detect.",
+        "id": "td-partial-branch-ratchet",
+        "label": "LCOV Partial-Branch Ratchet",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -953,6 +953,54 @@
         "id": "hook-exit-code-contract",
         "label": "Hook Exit-Code Contract",
         "maturity": "documented"
+      },
+      {
+        "description": "Enforce a single package manager per repo via a preinstall script that exits non-zero if the wrong one is invoked. Combined with engine-strict, prevents lockfile drift and npm/pnpm mixed installs that break reproducibility.",
+        "id": "ci-package-manager-exclusivity",
+        "label": "Package Manager Exclusivity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails on the presence of any unauthorized lockfile — e.g., a package-lock.json in a pnpm repo, or a yarn.lock in an npm repo. Companion to package-manager exclusivity; catches wrong-tool installs that slip past the preinstall guard.",
+        "id": "ci-lockfile-discipline",
+        "label": "Lockfile Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "package.json declares a pinned `packageManager` field (e.g., \"pnpm@9.15.0\") that Corepack and CI can use to auto-select the correct tool + version. Keeps the package-manager exclusivity guard and engine pins aligned with one authoritative source.",
+        "id": "de-packagemanager-field",
+        "label": "packageManager Field",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.",
+        "id": "de-editorconfig",
+        "label": "EditorConfig",
+        "maturity": "documented"
+      },
+      {
+        "description": "Set engine-strict=true in .npmrc (or equivalent) so the engines field in package.json becomes a hard install-time constraint, not advisory. Prevents 'works on my machine' drift from mismatched Node or package-manager versions.",
+        "id": "de-engine-strict",
+        "label": "engine-strict Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.",
+        "id": "qg-zero-warnings",
+        "label": "Zero-Warnings Lint Discipline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.",
+        "id": "sec-secret-scan-ci",
+        "label": "Full-History Secret Scan in CI",
+        "maturity": "documented"
+      },
+      {
+        "description": "Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.",
+        "id": "cr-semantic-release",
+        "label": "semantic-release Integration",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -1448,6 +1496,72 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
+      },
+      {
+        "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",
+        "id": "qg-justified-ignores",
+        "label": "Justified Lint Ignores",
+        "maturity": "documented"
+      },
+      {
+        "description": "Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.",
+        "id": "td-coverage-ratchet",
+        "label": "Coverage Ratchet (Raise-Only)",
+        "maturity": "documented"
+      },
+      {
+        "description": "Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.",
+        "id": "td-coverage-tiered",
+        "label": "Tiered Coverage Thresholds",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.",
+        "id": "td-coverage-delta-guard",
+        "label": "Coverage Delta Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.",
+        "id": "td-test-floor-contract",
+        "label": "Test Floor Contract",
+        "maturity": "documented"
+      },
+      {
+        "description": "Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.",
+        "id": "td-ratchet-bump-guard",
+        "label": "Ratchet Bump Equality Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.",
+        "id": "cr-threshold-change-guard",
+        "label": "Threshold Change Marker Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.",
+        "id": "cr-marker-bypass-convention",
+        "label": "Commit-Subject Marker Bypass Convention",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate scans workflows, scripts, and configs for forbidden package-manager commands — e.g., 'npm install' or 'npm ci' in a pnpm-exclusive repo. Catches drift that the preinstall guard alone won't: workflow-file edits that bypass installs entirely.",
+        "id": "ci-package-manager-command-guard",
+        "label": "Package-Manager Command Guard",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.",
+        "id": "sec-rule-disable-proof-artifact",
+        "label": "Rule-Disable Proof Artifact",
+        "maturity": "documented"
+      },
+      {
+        "description": "Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.",
+        "id": "sec-suppression-audit",
+        "label": "Suppression Audit with Baseline",
         "maturity": "documented"
       }
     ]

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -1568,7 +1568,7 @@
         "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
         "id": "p-schema-migration-parity",
         "label": "Schema/Migration Parity Test",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1577,7 +1577,7 @@
         "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
         "id": "p-migration-ddl-parity",
         "label": "Migration DDL Byte-Parity",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1586,7 +1586,7 @@
         "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
         "id": "p-required-tables-runtime-check",
         "label": "Required-Tables Runtime Check",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1595,7 +1595,7 @@
         "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
         "id": "p-schema-version-monotonic",
         "label": "Schema Version Seed Monotonic",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "conditions": [
@@ -1604,7 +1604,7 @@
         "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
         "id": "p-migration-test-coverage",
         "label": "Per-Migration Test Coverage",
-        "maturity": "documented"
+        "maturity": "template-available"
       },
       {
         "description": "Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.",

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -15,6 +15,7 @@
         "description": "Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.",
         "id": "gitattributes-eol",
         "label": "Git Attributes (Line Endings)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -52,6 +53,7 @@
         "description": "Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \\r characters. Detect this before running deeper CI steps.",
         "id": "crlf-detection",
         "label": "CRLF Detection in CI",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -79,6 +81,7 @@
         "description": "Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.",
         "id": "gitignore-and-dockerignore",
         "label": "Git and Docker Ignore Files",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitignore",
@@ -106,6 +109,7 @@
         "description": "Run static code linting to enforce consistency and catch common issues early.",
         "id": "linting",
         "label": "Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "eslint.config.js",
@@ -159,6 +163,7 @@
         "description": "Provide a deterministic unit test framework with a single command to run all tests.",
         "id": "unit-test-runner",
         "label": "Unit Test Runner",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -197,6 +202,7 @@
         "description": "Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.",
         "id": "containerization",
         "label": "Containerization (Docker / Docker Compose)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "Dockerfile",
@@ -225,6 +231,7 @@
         "description": "Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.",
         "id": "semantic-versioning",
         "label": "Semantic Versioning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".releaserc",
@@ -263,6 +270,7 @@
         "description": "If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.",
         "id": "version-guard",
         "label": "Version Guard (Automated Releases)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "scripts/check-version-unchanged.sh",
@@ -297,6 +305,7 @@
         "description": "Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.",
         "id": "release-artifact-exclusion",
         "label": "Release Artifact Formatter Exclusion",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".prettierignore",
@@ -325,6 +334,7 @@
         "description": "Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.",
         "id": "unified-release-workflow",
         "label": "Unified Release Workflow",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml",
@@ -361,6 +371,7 @@
         "description": "Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.",
         "id": "release-hook-bypass",
         "label": "Release Hook Bypass",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/release.yml"
@@ -390,6 +401,7 @@
         "description": "Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.",
         "id": "commit-linting",
         "label": "Commit Linting",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "commitlint.config.js",
@@ -423,6 +435,7 @@
         "description": "Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.",
         "id": "unit-test-reporter",
         "label": "Unit Test Reporter / Coverage",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -453,6 +466,7 @@
         "description": "Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.",
         "id": "ci-quality-gates",
         "label": "CI Quality Gates",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -482,6 +496,7 @@
         "description": "Automatic code formatting to maintain a consistent style across all contributors.",
         "id": "code-formatter",
         "label": "Code Formatter",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -515,6 +530,7 @@
         "description": "Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).",
         "id": "pre-commit-hooks",
         "label": "Pre-Commit Hooks",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".husky/",
@@ -543,6 +559,7 @@
         "description": "Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.",
         "id": "hook-ci-parity",
         "label": "Hook/CI Parity",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -571,6 +588,7 @@
         "description": "Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.",
         "id": "secret-scanning-precommit",
         "label": "Pre-commit Secret Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitleaks.toml",
@@ -597,6 +615,7 @@
         "description": "Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.",
         "id": "type-checking",
         "label": "Type Checking",
+        "maturity": "documented",
         "stack": {
           "bazelHints": {
             "commands": [
@@ -632,6 +651,7 @@
         "description": "Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.",
         "id": "dependency-security",
         "label": "Dependency Management & Vulnerability Scanning",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package-lock.json",
@@ -663,6 +683,7 @@
         "description": "Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.",
         "id": "deterministic-builds",
         "label": "Deterministic & Hermetic Builds",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "package-lock.json",
@@ -699,6 +720,7 @@
         "description": "Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.",
         "id": "provenance-security",
         "label": "Provenance & Security Metadata",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".github/workflows/codeql.yml",
@@ -731,6 +753,7 @@
         "description": "Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.",
         "id": "ci-templates-automation",
         "label": "CI Templates & Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".github/workflows/ci.yml",
@@ -763,6 +786,7 @@
         "description": "Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.",
         "id": "runtime-version",
         "label": "Runtime Version Specification",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -787,6 +811,7 @@
         "description": "Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.",
         "id": "documentation",
         "label": "Documentation Standards",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "README.md",
@@ -819,6 +844,7 @@
         "description": "Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.",
         "id": "repository-governance",
         "label": "Repository Governance",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "LICENSE",
@@ -851,6 +877,7 @@
         "description": "Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.",
         "id": "canonical-verify",
         "label": "Canonical Verify Entrypoint",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "package.json"
@@ -879,6 +906,7 @@
         "description": "Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.",
         "id": "config-authority",
         "label": "Config File Authority Rules",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".gitattributes",
@@ -905,6 +933,7 @@
         "description": "Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.",
         "id": "explicit-skip-paths",
         "label": "Explicit Skip Paths",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".eslintignore",
@@ -918,6 +947,12 @@
           "notes": "Define ignores in eslint.config.js (ignores array) and .prettierignore. Document why each path is excluded (generated code, vendor, etc.). Avoid ad-hoc --ignore-path flags in scripts.",
           "verification": "Review ignore configs and confirm all exclusions are documented and intentional."
         }
+      },
+      {
+        "description": "Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.",
+        "id": "hook-exit-code-contract",
+        "label": "Hook Exit-Code Contract",
+        "maturity": "documented"
       }
     ],
     "optionalEnhancements": [
@@ -933,6 +968,7 @@
         "description": "Standardize error handling and structured logging to make debugging and production monitoring easier.",
         "id": "observability",
         "label": "Observability (Logging & Error Handling)",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -955,6 +991,7 @@
         "description": "Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.",
         "id": "agent-phase-gates",
         "label": "Agent Phase Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "phase-gates.md"
@@ -979,6 +1016,7 @@
         "description": "Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.",
         "id": "agent-victory-gates",
         "label": "Agent Victory Gates",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "victory-gates.md"
@@ -1007,6 +1045,7 @@
         "description": "Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.",
         "id": "dependency-update-automation",
         "label": "Dependency Update Automation",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             "renovate.json",
@@ -1042,6 +1081,7 @@
         "description": "Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.",
         "id": "dependency-architecture-rules",
         "label": "Dependency Architecture Rules",
+        "maturity": "documented",
         "stack": {
           "anyOfFiles": [
             ".dependency-cruiser.cjs",
@@ -1074,6 +1114,7 @@
         "description": "Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.",
         "id": "integration-testing",
         "label": "Integration Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "jest.config.*",
@@ -1100,6 +1141,7 @@
         "description": "Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.",
         "id": "performance-baselining",
         "label": "Performance Baselines",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "lighthouserc.json"
@@ -1124,6 +1166,7 @@
         "description": "Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.",
         "id": "complexity-analysis",
         "label": "Complexity Analysis",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             ".eslintrc.*",
@@ -1149,6 +1192,7 @@
         "description": "Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.",
         "id": "accessibility-auditing",
         "label": "Accessibility Auditing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [],
           "exampleTools": [
@@ -1173,6 +1217,7 @@
         "description": "Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.",
         "id": "ai-drift-detection",
         "label": "AI Drift Detection",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "__snapshots__/",
@@ -1200,6 +1245,7 @@
         "description": "Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.",
         "id": "ai-schema-enforcement",
         "label": "AI Output Schema Enforcement",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/schemas/",
@@ -1228,6 +1274,7 @@
         "description": "Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.",
         "id": "ai-golden-tests",
         "label": "AI Golden Contract Tests",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "__fixtures__/ai-outputs/",
@@ -1255,6 +1302,7 @@
         "description": "Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.",
         "id": "ai-safety-checks",
         "label": "AI Adversarial & Safety Testing",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "tests/ai-safety/"
@@ -1281,6 +1329,7 @@
         "description": "Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.",
         "id": "ai-provenance-tracking",
         "label": "AI Provenance & Audit Logging",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "src/ai/provenance.ts"
@@ -1307,6 +1356,7 @@
         "description": "Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.",
         "id": "agent-invariants",
         "label": "Autonomous Agent Invariants",
+        "maturity": "documented",
         "stack": {
           "exampleConfigFiles": [
             "INVARIANTS.md"
@@ -1318,6 +1368,87 @@
           ],
           "verification": "INVARIANTS.md exists with machine-readable verification commands for all critical repository rules."
         }
+      },
+      {
+        "description": "A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.",
+        "id": "lcp-parity-doc",
+        "label": "Local/CI Parity Invariants Document",
+        "maturity": "documented"
+      },
+      {
+        "description": "Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.",
+        "id": "lcp-parity-doc-coverage-test",
+        "label": "Parity Doc Coverage Test",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.",
+        "id": "hook-tiered-model",
+        "label": "Tiered Hook Model",
+        "maturity": "documented"
+      },
+      {
+        "description": "Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.",
+        "id": "hook-dispatcher-script",
+        "label": "Hook Dispatcher Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'",
+        "id": "hook-preflight-script",
+        "label": "Pre-Push Preflight Script",
+        "maturity": "documented"
+      },
+      {
+        "description": "Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.",
+        "id": "hook-fail-fast-setup-check",
+        "label": "Fail-Fast Hook Setup Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.",
+        "id": "p-schema-migration-parity",
+        "label": "Schema/Migration Parity Test",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.",
+        "id": "p-migration-ddl-parity",
+        "label": "Migration DDL Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.",
+        "id": "p-required-tables-runtime-check",
+        "label": "Required-Tables Runtime Check",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.",
+        "id": "p-schema-version-monotonic",
+        "label": "Schema Version Seed Monotonic",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-database"
+        ],
+        "description": "Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.",
+        "id": "p-migration-test-coverage",
+        "label": "Per-Migration Test Coverage",
+        "maturity": "documented"
       }
     ]
   },

--- a/config/standards.typescript-js.json
+++ b/config/standards.typescript-js.json
@@ -1076,6 +1076,114 @@
           ],
           "verification": "victory-gates.md exists with milestone completion criteria and evidence requirements."
         }
+      },
+      {
+        "description": "Separate tsconfig files for typecheck (strict, bundler resolution), build (emit, CommonJS or ESM as appropriate), tests, and type-tests. A guard test locks module/moduleResolution per config so tsc cannot silently overwrite an IIFE bundle with a CommonJS one, or vice versa.",
+        "id": "qg-split-ts-configs",
+        "label": "Split TypeScript Configs",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.",
+        "id": "qg-no-any-types",
+        "label": "No any / Any Types",
+        "maturity": "documented"
+      },
+      {
+        "description": "Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.",
+        "id": "td-patch-coverage",
+        "label": "Patch Coverage Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.",
+        "id": "td-zero-skips",
+        "label": "Zero-Skips Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.",
+        "id": "td-platform-conditional-collection",
+        "label": "Platform-Conditional Test Collection Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.",
+        "id": "td-canonical-runtime",
+        "label": "Canonical Runtime Baseline",
+        "maturity": "documented"
+      },
+      {
+        "description": "Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.",
+        "id": "td-subprocess-isolated-collection",
+        "label": "Subprocess-Isolated Test Collection",
+        "maturity": "documented"
+      },
+      {
+        "description": "LCOV partial-branches baseline with a locked-zero files list. CI fails if a file on the locked-zero list develops any partial branches. Catches a class of untested conditional branches that line and statement coverage alone do not detect.",
+        "id": "td-partial-branch-ratchet",
+        "label": "LCOV Partial-Branch Ratchet",
+        "maturity": "documented"
+      },
+      {
+        "description": "When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.",
+        "id": "cr-shallow-clone-determinism",
+        "label": "Shallow-Clone Marker-Scan Determinism",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.",
+        "id": "ci-generated-artifact-byte-parity",
+        "label": "Generated-Artifact Byte-Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.",
+        "id": "ci-breaking-change-marker",
+        "label": "Breaking-Change Marker Gate",
+        "maturity": "documented"
+      },
+      {
+        "description": "Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.",
+        "id": "ci-cross-platform-test-count-parity",
+        "label": "Cross-Platform Test-Count Parity",
+        "maturity": "documented"
+      },
+      {
+        "description": "For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.",
+        "id": "sec-rule-disable-guardrail",
+        "label": "Rule-Disable Compensating Guardrail",
+        "maturity": "documented"
+      },
+      {
+        "description": "CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.",
+        "id": "sec-helper-enforcement",
+        "label": "Helper-Over-Primitive Enforcement",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.",
+        "id": "doc-cli-reference-drift",
+        "label": "CLI Reference Drift Guard",
+        "maturity": "documented"
+      },
+      {
+        "conditions": [
+          "has-cli"
+        ],
+        "description": "Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.",
+        "id": "doc-help-snapshots",
+        "label": "Per-Subcommand Help Snapshots",
+        "maturity": "documented"
+      },
+      {
+        "description": ".claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.",
+        "id": "ai-claude-hook-dispatch",
+        "label": "Claude Code Hook Dispatch",
+        "maturity": "documented"
       }
     ],
     "recommended": [

--- a/docs/migration/p0-pattern-extraction.md
+++ b/docs/migration/p0-pattern-extraction.md
@@ -273,7 +273,18 @@ Classified as fully covered by the listed existing item. Not added in P1.4/P1.4b
 | `cr-version-guard`           | `version-guard`                                                   | Existing item is essentially the same pattern.                                                         |
 | `ai-agent-safety-invariants` | `agent-invariants` (+ `agent-phase-gates`, `agent-victory-gates`) | Existing trio already covers INVARIANTS.md + phase/victory gates.                                      |
 
-### Not yet processed — deferred to P1.5 (Optional tier)
+### P1.5 — 18 Optional items
 
-18 Optional-tier catalog items remain untouched. Scheduled for P1.5 in one batch:
-`qg-split-ts-configs`, `qg-no-any-types`, `td-patch-coverage`, `td-zero-skips`, `td-platform-conditional-collection`, `td-canonical-runtime`, `td-subprocess-isolated-collection`, `td-partial-branch-ratchet`, `cr-shallow-clone-determinism`, `ci-generated-artifact-byte-parity`, `ci-breaking-change-marker`, `ci-cross-platform-test-count-parity`, `sec-rule-disable-guardrail`, `sec-subprocess-allowlist`, `sec-helper-enforcement`, `doc-cli-reference-drift` (conditional on has-cli), `doc-help-snapshots` (conditional on has-cli), `ai-claude-hook-dispatch`.
+All Optional-tier catalog items added in a single batch. Per-item stack applicability:
+
+- **TypeScript-only:** `qg-split-ts-configs`, `td-partial-branch-ratchet`
+- **TypeScript + Python:** `qg-no-any-types`
+- **Python-only:** `sec-subprocess-allowlist`
+- **All stacks:** `td-patch-coverage`, `td-zero-skips`, `td-platform-conditional-collection`, `td-canonical-runtime`, `td-subprocess-isolated-collection`, `cr-shallow-clone-determinism`, `ci-generated-artifact-byte-parity`, `ci-breaking-change-marker`, `ci-cross-platform-test-count-parity`, `sec-rule-disable-guardrail`, `sec-helper-enforcement`, `ai-claude-hook-dispatch`
+- **All stacks, `conditions: ["has-cli"]`:** `doc-cli-reference-drift`, `doc-help-snapshots`
+
+All ship at `maturity: "documented"` with `enforcement: "optional"` and `severity: "info"`. Descriptions lift the pattern's intent and defect-class prevention from the Section 4 catalog entries.
+
+### Closing state (post-P1.5)
+
+Catalog totals: **38 Core + 34 Recommended + 21 Optional = 93 items** (up from 44 pre-P1). Every item carries `maturity`; persistence items carry `conditions: ["has-database"]`; CLI-documentation items carry `conditions: ["has-cli"]`. The 8 DUPLICATE-classified catalog items remain deferred per the table above; revisit if template work in P2 surfaces a concrete distinction.

--- a/docs/migration/p0-pattern-extraction.md
+++ b/docs/migration/p0-pattern-extraction.md
@@ -1,0 +1,238 @@
+# P0 — Pattern Extraction & Traceability Matrix
+
+**Status:** Approved with refinements (2026-04-20) — ready to hand off to P1
+**Purpose:** Catalog every reusable quality-gate pattern targeted for migration into `@oddessentials/repo-standards` so consumers inherit them as defaults rather than rediscovering them in production. One row per pattern, classified by tier, stack applicability, and implementation maturity.
+**Scope:** Planning artifact only. No `config/standards.json` edits, no templates, no code changes until the decisions here are executed by the numbered phases.
+
+---
+
+## 1. Why this document exists
+
+The patterns catalogued below are drawn from production-hardened multi-stack repos: hook dispatchers, ratchet gates, parity matrices, rule-disable proofs, schema-migration invariants, marker-based bypass conventions. They represent defect-class prevention that's easy to miss when standing up a new repo and expensive to retrofit. This doc is the review surface for _which_ of those patterns flow into `repo-standards`, _at what tier_, _for which stacks_, and _with what implementation maturity_. It is the contract that P1 (policy-lane), P2 (template-lane), P3 (`apply`-extension), and P4 (dogfood) execute against.
+
+## 2. Classification rubric
+
+### Tier
+
+- **Core.** Applies to essentially all serious repos. Low implementation cost. Pattern prevents a defect class that is common and high-impact, or it's a near-universal ecosystem convention. Not opinionated beyond "do this or explain why not."
+- **Recommended.** Applies to most repos but not all. Moderate implementation cost. Significant quality/safety win. Some opinionation — the pattern has design choices consumers may want to adapt.
+- **Recommended (conditional on X).** Recommended _if_ condition X holds. Marked when a pattern only has value paired with another adopted pattern, or when it only applies to a subset of repos.
+- **Optional.** Applies to hardened / mature repos, or to a specific scenario (has-a-database, ships-compiled-UI-bundle, etc.). Higher implementation cost or higher opinionation. Good pattern, but not the first thing a new repo should adopt.
+
+### Stack applicability
+
+- **All.** Universal — language-agnostic, works anywhere.
+- **All (concept); {stacks} (impl).** Principle is universal; first-class reference implementation exists for the listed stacks. Others adapt idiomatically.
+- **{stacks}.** Only applies to the listed stacks.
+- **Conditional on {X}.** Only applies if condition holds (e.g., "conditional on shipping a relational schema").
+
+### Implementation maturity
+
+Every checklist item shipped to `config/standards.json` carries an `implementation_maturity` field so consumers can tell _documented_ from _ready-to-copy_:
+
+- `documented` — pattern described in instructions/docs; no template shipped yet.
+- `template-planned` — template scheduled for a named milestone, not yet written.
+- `template-available` — template exists under `templates/patterns/<id>/`; consumers can copy-and-adapt immediately.
+
+**P1 constraint:** any checklist item landing before its template exists MUST set `implementation_maturity` to `documented` or `template-planned` so it isn't surfaced as ready-to-adopt. The field is exposed in the generated `instructions.<stack>.md` so consumers see it directly.
+
+## 3. Category inventory
+
+| #   | Category                   | Scope                                                                            |
+| --- | -------------------------- | -------------------------------------------------------------------------------- |
+| 1   | `local-ci-parity`          | Parity doc + the test that keeps the doc honest                                  |
+| 2   | `hooks-and-orchestration`  | Tiered hook model, dispatcher scripts, exit-code contract                        |
+| 3   | `quality-gates`            | Linters, formatters, type checkers, split TS configs                             |
+| 4   | `test-discipline`          | Coverage thresholds, test-count floors, ratchets, platform filtering             |
+| 5   | `commit-and-release`       | Conventional commits, semantic-release, version/threshold guards, bypass markers |
+| 6   | `ci-infrastructure`        | Workflow-level guards: lockfile, package-manager, line-ending, artifact parity   |
+| 7   | `security-gates`           | Secret scan, suppression audit, rule-disable proofs, command allowlists          |
+| 8   | `dev-environment`          | Engines pins, editorconfig, package-manager exclusivity                          |
+| 9   | `documentation-invariants` | CLI reference drift, generated-artifact byte-parity                              |
+| 10  | **`persistence` (NEW)**    | Schema/migration parity, DDL byte-equivalence, required-tables runtime           |
+| 11  | `agent-integration`        | `.claude/settings.json` dispatch, agent-safety invariants                        |
+| 12  | `meta-patterns`            | Cross-cutting design principles (adversarial-proof, churn-bait discipline, etc.) |
+
+## 4. Pattern catalog
+
+New items added in this P0 pass (versus the initial strategy sketch) are flagged **🆕**.
+
+### 4.1 `local-ci-parity`
+
+| ID                                | Pattern                                                                                                                                                                                                 | Tier | Stacks                       |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ---------------------------- |
+| `lcp-parity-doc`                  | Row-per-gate matrix (e.g., `LOCAL_CI_PARITY_INVARIANTS.md`) citing every local gate with its CI equivalent + Match/Weaker/Partial status                                                                | Rec  | All                          |
+| `lcp-parity-doc-coverage-test` 🆕 | AST-walk the preflight runner; assert every gate's canonical identifier appears as a double-quoted string in the parity doc. Adversarial negative tests required (see `mp-adversarial-proof-required`). | Rec  | All (concept); Python (impl) |
+
+**Scope-discipline note for `lcp-parity-doc-coverage-test` (load-bearing):** The test locks _canonical identifier presence only_. It must NOT be extended to lock prose, row counts, link shapes, or Prevention-Proof wording. Doing so makes the test churn-bait and consumers will remove it. This note belongs verbatim in the template README.
+
+### 4.2 `hooks-and-orchestration`
+
+| ID                           | Pattern                                                                                                                                                                                         | Tier     | Stacks                                      |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------------------------------------- |
+| `hook-tiered-model`          | Tier 1 (pre-commit, staged-only, fast) → Tier 2 (pre-push, CI-identical preflight) → Tier 3 (CI-only)                                                                                           | Rec      | All                                         |
+| `hook-dispatcher-script`     | Single entrypoint that routes `pre-commit` / `pre-push` / `commit-msg` based on argv, handles tool-missing / network cases cleanly                                                              | Rec      | All (concept); Python or POSIX shell (impl) |
+| `hook-preflight-script`      | Single entrypoint that runs the CI-identical superset; pre-push delegates to it                                                                                                                 | Rec      | All (concept); Python or POSIX shell (impl) |
+| `hook-exit-code-contract`    | `EXIT_GATE=1` (quality regression, fatal), `EXIT_SETUP=2` (tool missing, fatal), `EXIT_INFRA=3` (network, skippable with `--allow-local-degraded`). Contract identical across all hook scripts. | **Core** | All                                         |
+| `hook-fail-fast-setup-check` | Upfront validation that `.husky/` exists and hook harness is installed before running any gates                                                                                                 | Rec      | All                                         |
+
+### 4.3 `quality-gates`
+
+| ID                     | Pattern                                                                                                                                                               | Tier | Stacks                   |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------------------ |
+| `qg-zero-warnings`     | Lint runs with `--max-warnings=0` (or equivalent); warning == failure                                                                                                 | Core | All                      |
+| `qg-strict-types`      | Strict type checker enabled across src/ with documented per-module overrides (mypy strict, tsc strict, etc.)                                                          | Core | TS, Python, Rust, Go, C# |
+| `qg-justified-ignores` | Every linter ignore / suppression includes a comment justifying it; zero silent suppressions                                                                          | Rec  | All                      |
+| `qg-split-ts-configs`  | Separate `tsconfig.json` / `tsconfig.build.json` / `tsconfig.test.json` / `tsconfig.type-tests.json` with a guard test locking `module`/`moduleResolution` per config | Opt  | TS                       |
+| `qg-no-any-types`      | Guard that forbids `typing.Any` / `any` in src/, tests/, scripts/ with allowlist for justified cases                                                                  | Opt  | TS, Python               |
+
+### 4.4 `test-discipline`
+
+| ID                                   | Pattern                                                                                                                                               | Tier | Stacks                          |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------------------------- |
+| `td-coverage-threshold`              | Coverage threshold enforced in CI; consumers set their own floor                                                                                      | Core | All                             |
+| `td-coverage-ratchet`                | Threshold formula `floor(actual - 2.0)`; raise-only; CI fails on regression                                                                           | Rec  | All                             |
+| `td-coverage-tiered`                 | Global baseline + per-file Tier 2 thresholds for critical paths (schemas, parsers, security boundaries)                                               | Rec  | All                             |
+| `td-coverage-delta-guard`            | Coverage-delta gate (e.g., no drop > 2% between PR and main)                                                                                          | Rec  | All                             |
+| `td-patch-coverage`                  | Patch coverage must meet threshold; Codecov project status parity                                                                                     | Opt  | All                             |
+| `td-test-floor-contract`             | `.test-floor-contract.json` pins `min_collected` count; CI reads authoritatively (no hardcoded integers)                                              | Rec  | All                             |
+| `td-ratchet-bump-guard`              | Per-commit equality check: `collected == floor` after any floor bump; walks first-parent range; subprocess-isolated collection to match CI exactly    | Rec  | All (concept); Python (impl)    |
+| `td-zero-skips`                      | `--max-skips=0` zero-tolerance skip gate; collection-time exclusion > `pytest.mark.skip`                                                              | Opt  | Python (impl); concept portable |
+| `td-platform-conditional-collection` | Shared glob patterns imported by both `conftest.py` and the ratchet gate; AST-level parity test asserts both sites import the same constant           | Opt  | Python (impl); concept portable |
+| `td-canonical-runtime`               | One canonical OS + runtime version used for threshold comparison (e.g., ubuntu-latest + Python 3.12); other matrix legs don't gate thresholds         | Opt  | All                             |
+| `td-subprocess-isolated-collection`  | Test collection runs in a clean subprocess (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`, cleared addopts) with count written to a tempfile — no stdout parsing | Opt  | Python (impl); concept portable |
+| `td-partial-branch-ratchet`          | LCOV partial-branches baseline with locked-zero files list                                                                                            | Opt  | TS                              |
+
+### 4.5 `commit-and-release`
+
+| ID                             | Pattern                                                                                                                                                                                                                                                  | Tier                                                                  | Stacks                     |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------- |
+| `cr-conventional-commits`      | Commitlint with `@commitlint/config-conventional`; extended `type-enum` for project-specific types (e.g., `ratchet`)                                                                                                                                     | Core                                                                  | All                        |
+| `cr-semantic-release`          | semantic-release on `main` only; git plugin commits version files; `[skip ci]` convention                                                                                                                                                                | Rec                                                                   | All                        |
+| `cr-version-guard`             | Pre-push gate blocks manual version bumps when semantic-release owns versioning. Bypass: subject-line `[version-override-acknowledged]`. Never bypassed for direct-to-main pushes.                                                                       | Rec                                                                   | All (concept); Node (impl) |
+| `cr-threshold-change-guard`    | CI gate blocks coverage-threshold changes unless commit subject includes `[threshold-update]` marker                                                                                                                                                     | Rec                                                                   | All                        |
+| `cr-marker-bypass-convention`  | Subject-line-only markers for documented bypass cases (`[threshold-update]`, `[ratchet-realignment]`, `[ratchet-test-removal]`, `[version-override-acknowledged]`); bodies ignored; scanned via `git log --oneline` with shallow-clone determinism guard | **Rec (conditional on adopting any ratchet/threshold/version guard)** | All                        |
+| `cr-shallow-clone-determinism` | When scanning commits for markers, fetch without `--depth=N`; cross-check `git log {base}..HEAD` against `git rev-list --count`; fail if they disagree                                                                                                   | Opt                                                                   | All                        |
+
+### 4.6 `ci-infrastructure`
+
+| ID                                    | Pattern                                                                                                                            | Tier | Stacks                                      |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---- | ------------------------------------------- |
+| `ci-package-manager-exclusivity`      | Preinstall script exits 1 if wrong package manager is used. Examples: pnpm-only repos reject npm; `engine-strict=true` in `.npmrc` | Core | Node                                        |
+| `ci-lockfile-discipline`              | CI gate fails on presence of wrong lockfile (e.g., zero `package-lock.json` outside `node_modules/` in a pnpm repo)                | Core | Node                                        |
+| `ci-package-manager-command-guard`    | CI gate scans workflows/scripts/configs for forbidden package-manager commands (e.g., `npm install`/`npm ci` in a pnpm repo)       | Rec  | Node                                        |
+| `ci-line-ending-guard`                | CRLF detector for hooks, shell scripts, CI scripts, bundled UI. Prevents package imports from introducing CRLF                     | Core | All                                         |
+| `ci-generated-artifact-byte-parity`   | CI verifies any checked-in generated artifact is byte-identical to what a fresh generation would produce                           | Opt  | Conditional on shipping generated artifacts |
+| `ci-breaking-change-marker`           | CI gate blocks major-version bumps of contract files unless commit message contains a `BREAKING <CONTRACT>:` marker                | Opt  | Conditional on shipping versioned contracts |
+| `ci-cross-platform-test-count-parity` | Compare test counts between OS matrix legs (ubuntu vs windows) to catch platform-filter bugs                                       | Opt  | All                                         |
+
+### 4.7 `security-gates`
+
+| ID                                | Pattern                                                                                                                                                                                                | Tier | Stacks                       |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---- | ---------------------------- |
+| `sec-secret-scan`                 | gitleaks with project allowlist; full-history scan on PR (`fetch-depth: 0`)                                                                                                                            | Core | All                          |
+| `sec-dependency-audit`            | `npm audit --audit-level=high` (or stack equivalent) in pre-push + CI                                                                                                                                  | Core | All                          |
+| `sec-rule-disable-proof-artifact` | For every globally disabled lint rule, ship a committed proof artifact (e.g., `.rule-disable-audit-<rule>.json`) listing every call-site and the compensating control. Exact-match check on every run. | Rec  | All                          |
+| `sec-rule-disable-guardrail`      | For every globally disabled rule, ship a custom validator that enforces the compensating control. Uses tokenizer (not regex) to avoid false positives in string literals.                              | Opt  | All (concept); Python (impl) |
+| `sec-suppression-audit`           | Scope-based suppression baseline (e.g., `.suppression-baseline.json`) with zero-tolerance `scope_policy: blocking`. Baseline regenerated and staleness-checked on every run.                           | Rec  | All                          |
+| `sec-subprocess-allowlist`        | Whitelist for repo-owned non-literal subprocess commands; verified by guardrail                                                                                                                        | Opt  | Python                       |
+| `sec-helper-enforcement`          | CI gate that blocks direct use of primitives where a safer helper is required (example: pagination tokens must route through a wrapper rather than being concatenated directly)                        | Opt  | All (pattern-level)          |
+
+### 4.8 `dev-environment`
+
+| ID                        | Pattern                                                                                                                                                        | Tier | Stacks |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ------ |
+| `de-engines-pinned`       | `engines` field in `package.json` pins node + package-manager version; `.nvmrc` / `.tool-versions` / `pyproject.toml:requires-python` for the language runtime | Core | All    |
+| `de-packagemanager-field` | `packageManager` field in `package.json` matches engines pin; validated by a CI guard                                                                          | Core | Node   |
+| `de-editorconfig`         | `.editorconfig` with UTF-8, LF, trim trailing whitespace, final newline; explicit overrides for Python (4-space), JSON/YAML (2-space), Windows batch (CRLF)    | Core | All    |
+| `de-engine-strict`        | `.npmrc` sets `engine-strict=true` to enforce engines field                                                                                                    | Core | Node   |
+
+### 4.9 `documentation-invariants`
+
+| ID                        | Pattern                                                                                                                                                                                                 | Tier | Stacks                        |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ----------------------------- |
+| `doc-cli-reference-drift` | Auto-generated CLI reference with golden-SHA check. Canonical Python only (argparse rendering differs across versions). `--check` mode returns `[SKIP]` on non-canonical runtime (fail-close on write). | Opt  | Conditional on shipping a CLI |
+| `doc-help-snapshots`      | Per-subcommand help snapshots committed for diff visibility                                                                                                                                             | Opt  | Conditional on shipping a CLI |
+
+### 4.10 `persistence` 🆕
+
+| ID                                   | Pattern                                                                                                                                                                                            | Tier | Stacks                           |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | -------------------------------- |
+| `p-schema-migration-parity` 🆕       | Parity test: every table declared in the canonical schema source MUST either be in a designated "fundamental" set OR be created by at least one registered migration. Test-only, no runtime hooks. | Rec  | All (concept); Python (impl)     |
+| `p-migration-ddl-parity` 🆕          | PRAGMA/DDL byte-equivalence between the canonical schema source and a DB built by running all migrations against a blank start                                                                     | Opt  | Conditional on relational schema |
+| `p-required-tables-runtime-check` 🆕 | Two-phase runtime validation at DB connect: "fundamental" tables must exist before migrations run; "required" tables must exist after. Defense-in-depth alongside the parity test.                 | Rec  | Conditional on relational schema |
+| `p-schema-version-monotonic` 🆕      | CI gate: `schema_version` seed in canonical SQL matches `max(target_version)` in the migration registry. Catches "added migration, forgot to bump seed."                                           | Rec  | Conditional on relational schema |
+| `p-migration-test-coverage` 🆕       | Every registered migration has at least one test exercising it: (a) on a blank DB, (b) on the prior schema version. Enforced by a coverage check over the migration registry.                      | Rec  | Conditional on relational schema |
+
+**Applicability note:** All `persistence` items are conditional on the repo shipping a relational schema + migration registry. For repos without, all items evaluate as N/A (same mechanism as existing stack-applicability). We'll define "has-a-database" via a file-scanner signal in P1 (e.g., presence of a `migrations/` directory, or a `persistence.declared` metadata field).
+
+### 4.11 `agent-integration`
+
+| ID                           | Pattern                                                                                                                                                   | Tier | Stacks |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---- | ------ |
+| `ai-claude-hook-dispatch`    | `.claude/settings.json` with pre/post/session hooks dispatching to a single orchestrator (binary or stack-native dispatcher)                              | Opt  | All    |
+| `ai-agent-safety-invariants` | Ship `INVARIANTS.md` + phase-gates + victory-gates per the existing templates in this repo. _Already present; pattern is about ensuring consumers adopt._ | Rec  | All    |
+
+### 4.12 `meta-patterns` (cross-cutting design principles)
+
+These are not individual checklist items — they are design principles that apply _across_ multiple patterns and belong in the template READMEs for every pattern they govern. They will be delivered as a single `docs/patterns/meta-principles.md` that every template's README links to in a standard "Design principles this template obeys" footer.
+
+| ID                                      | Principle                                                                                                                                                                                                                                                 |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mp-adversarial-proof-required` 🆕      | Any invariant-asserting test MUST include adversarial negative tests proving it catches the regression case. Without proof-of-catch, "enforcement" is unverified. Applies to: parity tests, ratchet gates, rule-disable guardrails, any `check_*` script. |
+| `mp-churn-bait-discipline` 🆕           | Parity / drift tests lock _canonical identifiers_ only, never prose/wording/row-counts/link-shapes. Violations turn the test into a maintenance burden and consumers will remove it.                                                                      |
+| `mp-committed-proof-artifacts`          | Any claim that is hard to verify by code inspection alone (disabled-rule safety, subprocess-allowlist coverage, fundamental-table membership) should be backed by a committed JSON manifest that is diffable in PR and exact-match-checked on every run.  |
+| `mp-defense-in-depth`                   | Where feasible, pair a _shift-left_ gate (PR-time parity test) with a _runtime_ gate (connect-time / request-time check). They catch the same defect class at different costs.                                                                            |
+| `mp-point-in-time-structural-claims` 🆕 | Any structural claim in a pattern doc (counts, file lists, identifier inventories) is verified-at-commit, not eternal. Pattern docs should say so explicitly and tell implementers to re-verify before acting.                                            |
+| `mp-authoritative-contract-file`        | Where a number or invariant is shared across multiple sites (CI + local preflight + ratchet gate), put it in a single contract JSON with an `authority` field pointing at the canonical producer. No hardcoded integers in multiple places.               |
+| `mp-enforce-helpers-over-primitives`    | When a helper exists to make an operation safe, CI should forbid direct use of the underlying primitive. The helper's existence is not enough — the primitive must be blocked.                                                                            |
+| `mp-allowlist-over-blocklist`           | For security-sensitive surfaces (subprocess commands, CI-runnable actions, dependency sources), allowlist known-good. Blocklists of known-bad are unbounded.                                                                                              |
+
+## 5. Deferred / out-of-scope
+
+Patterns explicitly NOT migrating in this pass, with reason:
+
+| Pattern                                                                                                                  | Reason                                                                                                                                                               |
+| ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| External monorepo hook-dispatcher integrations                                                                           | Project-specific orchestration binaries aren't generalizable. Consumers should wire their own dispatcher; the `hook-dispatcher-script` pattern gives them the shape. |
+| Azure DevOps extension / VSIX-specific patterns (task major-version guards, VSIX inspection, extension version-stamping) | Too narrow — specific to ADO extension repos. If there's demand we can ship a `vsix-extension` template pack later, but it doesn't belong in the base catalog.       |
+| Tool-version alignment for language-specific ecosystem stubs (e.g., pandas-stubs ↔ pandas major version)                 | Ecosystem-specific; the _principle_ (tool-version consistency) is already captured by `de-engines-pinned` + possible future `de-tool-version-consistency`.           |
+| Compiled UI bundle synchronization specifics                                                                             | The _principle_ is captured as `ci-generated-artifact-byte-parity`; specific implementation details stay in the consumer's repo.                                     |
+| Synthetic-dataset / demo workflow patterns                                                                               | Single-purpose demo-generation flows, not generalizable.                                                                                                             |
+
+## 6. Decisions log
+
+Resolved during review (2026-04-20):
+
+1. **Category name: `persistence`.** ✅ Resolved. Five items in the new category, all conditional on relational schema.
+2. **`hook-exit-code-contract` tier.** ✅ Stays **Core**. It's small but foundational glue for any hook ecosystem — inconsistent exit semantics create ambiguity immediately. Cheap to adopt.
+3. **`sec-suppression-audit` tier.** ✅ Stays **Recommended**. Value is real but setup cost is materially higher than strict-types / line-ending / package-manager items. Keeping it Recommended preserves credibility.
+4. **`cr-marker-bypass-convention` tier.** ✅ Changed to **Recommended (conditional on adopting any ratchet/threshold/version guard)**. Essential once those guards exist; policy surface without them.
+5. **`sec-rule-disable-proof-artifact` tier.** ✅ Stays **Recommended**. Borderline but more opinionated than `qg-zero-warnings` / `de-editorconfig`; not ready to promote to Core-as-project-philosophy.
+6. **Stack-first coverage for templates.** ✅ **Python + TS first; concept-documented for others.** Avoids fake generality. Better to ship excellent first-class examples for the dominant source patterns than weak pseudo-templates for every stack.
+7. **Template-drift prevention strategy.** ✅ **Vendored templates with provenance.** Re-fetch-and-diff CI is too expensive for this phase; URL-only references would undermine the "copy and implement now" goal. **Provenance lives in template READMEs only**, in the single-line form `adapted from <source>@<sha>`. It does NOT appear in `config/standards.json`, in `instructions.<stack>.md`, or in any policy doc. That specific line in each `templates/patterns/<id>/README.md` is the only in-repo surface where provenance is permitted.
+8. **Meta-patterns delivery.** ✅ Single `docs/patterns/meta-principles.md` that every pattern template's README links to in a standard "Design principles this template obeys" footer. (No objection raised in review; adopted.)
+9. **Implementation-maturity signal — machine-enforced.** ✅ **New requirement.** Every checklist item in `config/standards.json` carries a **required** `maturity` field with values `documented` / `template-planned` / `template-available`. Schema validation rejects items missing the field — not a documentation convention, not a lint, a hard schema constraint. Items landing in P1 before their P2 template exists must be one of the first two. Surfaced inline in generated `instructions.<stack>.md` so consumers can tell ready-to-copy from documented-only. (See Section 2.)
+10. **Project-agnostic content.** ✅ **New constraint.** Nothing in `config/standards.json`, `instructions.<stack>.md`, or any policy doc names origin projects. Patterns are described by _what they do_ and _what defect class they prevent_. The only in-repo place provenance may appear is a single-line `adapted from <source>@<sha>` in template READMEs (see decision 7).
+11. **Conditions mechanism — first-class, not deferred.** ✅ **New decision.** A `conditions` array on each checklist item (e.g., `["has-database"]`, `["has-cli"]`) is a P1 deliverable. Detection via file-based heuristics (`migrations/` present, `package.json:bin` defined, etc.), with an optional override in a consumer repo-config file. Conditional items render as "not applicable" in `verify` output when the condition doesn't hold. Without this, conditional items become noise in `verify` within 2–3 iterations.
+12. **Verify / doctor output — tier-grouped, Core-first.** ✅ **New constraint.** Output groups findings by tier (Core / Recommended / Optional) and surfaces Core failures first. Progress shown as per-tier completion percentages, not just total-failure count. This is not UX polish — walls of check names undermine adoption and turn the catalog into background noise.
+13. **Meta-principles footer in every template README — unavoidable.** ✅ **New constraint.** Every `templates/patterns/<id>/README.md` ends with a standard footer: "This pattern follows: <mp-ids>" linking to `docs/patterns/meta-principles.md`. A P2 CI gate verifies footer presence across all pattern READMEs so meta-principles don't rot into ignored prose.
+
+## 7. What's next for P1
+
+P1 delivers in this order — consumer-visible impact first, so each step produces something observable in `verify` output before moving on:
+
+1. **Schema change + tier-grouped verify output + Core items.** Extend `config/standards.json` schema with required `maturity` (enum of `documented` / `template-planned` / `template-available`) and optional `conditions` (string array). Update `verify` / `doctor` output to group findings by tier and surface Core failures first. Add every Core-tier item from Sections 4.1–4.11. Acceptance: a consumer running `verify` immediately sees new Core additions under a clearly labeled "Core" grouping with per-tier progress.
+2. **Maturity signal wiring.** Schema validation rejects items missing `maturity`. Generated `instructions.<stack>.md` surfaces the maturity value inline for every item. Acceptance: items with `maturity: documented` render visibly distinct from `template-available` ones; a missing `maturity` field causes spec generation to fail loudly.
+3. **Conditions mechanism.** File-based detection (`migrations/`, `package.json:bin`, etc.) + optional override in a repo-config file. Conditional items render as "N/A — condition X not met" in `verify` output when the condition doesn't hold. Acceptance: persistence items evaluate as N/A in a repo without a schema; evaluate as active in a repo that declares one.
+4. **Recommended items.** Add all Recommended patterns (including the conditional-Recommended `cr-marker-bypass-convention`).
+5. **Optional items.** Add all Optional patterns last. Spec is now complete.
+6. **Meta-principles doc.** Ship `docs/patterns/meta-principles.md` capturing Section 4.12. This sets up P2's template-README footer convention.
+
+**P1 acceptance check:** generated `instructions.<stack>.md` for every supported stack compiles cleanly; new patterns render at the right tier with accurate maturity; conditional items render "N/A" when their condition is unmet; `verify` output is tier-grouped and surfaces Core failures first; schema validation rejects any item missing `maturity`.
+
+P2 follows with templates (Python + TS first) under `templates/patterns/<id>/`. Each README carries scope-discipline notes where applicable (especially `lcp-parity-doc-coverage-test` and any other test that locks identifier presence), a one-line `adapted from <source>@<sha>` provenance line, and the standard meta-principles footer. A P2 CI gate enforces footer presence across all pattern READMEs.
+
+---
+
+**Document status:** approved with P1 hardening (2026-04-20). P1 may begin.

--- a/docs/migration/p0-pattern-extraction.md
+++ b/docs/migration/p0-pattern-extraction.md
@@ -236,3 +236,44 @@ P2 follows with templates (Python + TS first) under `templates/patterns/<id>/`. 
 ---
 
 **Document status:** approved with P1 hardening (2026-04-20). P1 may begin.
+
+---
+
+## Appendix A — P1.4/P1.4b cross-reference outcomes
+
+Resolution of each catalog item against existing `config/standards.json` entries, recorded as items landed. Kept as a traceability record so the DUPLICATE classifications can be revisited if future evidence changes the judgment.
+
+### Added as new items (P1.4 / P1.4b)
+
+**P1.4 — 1 Core + 11 Recommended:**
+
+- `hook-exit-code-contract` (Core)
+- `lcp-parity-doc`, `lcp-parity-doc-coverage-test` (Rec)
+- `hook-tiered-model`, `hook-dispatcher-script`, `hook-preflight-script`, `hook-fail-fast-setup-check` (Rec)
+- `p-schema-migration-parity`, `p-migration-ddl-parity`, `p-required-tables-runtime-check`, `p-schema-version-monotonic`, `p-migration-test-coverage` (Rec, conditional on `has-database`)
+
+**P1.4b — 8 Core + 11 Recommended:**
+
+- Net-new Core: `ci-package-manager-exclusivity`, `ci-lockfile-discipline`, `de-packagemanager-field`, `de-editorconfig`, `de-engine-strict`
+- Complement Core (adds distinct discipline over an existing item): `qg-zero-warnings`, `sec-secret-scan-ci`, `cr-semantic-release`
+- Net-new Recommended: `qg-justified-ignores`, `td-coverage-ratchet`, `td-coverage-tiered`, `td-coverage-delta-guard`, `td-test-floor-contract`, `td-ratchet-bump-guard`, `cr-threshold-change-guard`, `cr-marker-bypass-convention`, `ci-package-manager-command-guard`, `sec-rule-disable-proof-artifact`, `sec-suppression-audit`
+
+### Deferred as DUPLICATE of an existing item
+
+Classified as fully covered by the listed existing item. Not added in P1.4/P1.4b. Revisit if a concrete distinction emerges during template work in P2.
+
+| Catalog ID                   | Covered by existing item                                          | Notes                                                                                                  |
+| ---------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `qg-strict-types`            | `type-checking`                                                   | Existing item already calls out strictness on new code.                                                |
+| `td-coverage-threshold`      | `unit-test-reporter`                                              | Existing item sets an ~80% threshold. The ratchet + tiered + delta patterns were added as complements. |
+| `cr-conventional-commits`    | `commit-linting`                                                  | Existing item explicitly names Conventional Commits.                                                   |
+| `ci-line-ending-guard`       | `crlf-detection` + `gitattributes-eol`                            | Existing two items cover CI CRLF detection and source-layer EOL enforcement.                           |
+| `sec-dependency-audit`       | `dependency-security`                                             | Existing item covers lockfile + vuln scanning + CI fail-on-high.                                       |
+| `de-engines-pinned`          | `runtime-version`                                                 | Existing item covers `engines` field and runtime pins.                                                 |
+| `cr-version-guard`           | `version-guard`                                                   | Existing item is essentially the same pattern.                                                         |
+| `ai-agent-safety-invariants` | `agent-invariants` (+ `agent-phase-gates`, `agent-victory-gates`) | Existing trio already covers INVARIANTS.md + phase/victory gates.                                      |
+
+### Not yet processed — deferred to P1.5 (Optional tier)
+
+18 Optional-tier catalog items remain untouched. Scheduled for P1.5 in one batch:
+`qg-split-ts-configs`, `qg-no-any-types`, `td-patch-coverage`, `td-zero-skips`, `td-platform-conditional-collection`, `td-canonical-runtime`, `td-subprocess-isolated-collection`, `td-partial-branch-ratchet`, `cr-shallow-clone-determinism`, `ci-generated-artifact-byte-parity`, `ci-breaking-change-marker`, `ci-cross-platform-test-count-parity`, `sec-rule-disable-guardrail`, `sec-subprocess-allowlist`, `sec-helper-enforcement`, `doc-cli-reference-drift` (conditional on has-cli), `doc-help-snapshots` (conditional on has-cli), `ai-claude-hook-dispatch`.

--- a/docs/migration/p0-pattern-extraction.md
+++ b/docs/migration/p0-pattern-extraction.md
@@ -235,7 +235,7 @@ P2 follows with templates (Python + TS first) under `templates/patterns/<id>/`. 
 
 ---
 
-**Document status:** approved with P1 hardening (2026-04-20). P1 may begin.
+**Document status:** P1 complete (2026-04-20). All six P1 deliverables shipped: schema foundation + tier-grouped verify output (P1.1), maturity signal wiring (P1.2), conditions mechanism (P1.3), net-new + complement items across both tiers (P1.4 + P1.4b + P1.5 — 49 items added total), and `docs/patterns/meta-principles.md` (P1.6). Next phase is P2 (template-lane — see Section 7).
 
 ---
 

--- a/docs/patterns/meta-principles.md
+++ b/docs/patterns/meta-principles.md
@@ -1,0 +1,221 @@
+# Meta-Principles for Quality-Gate Patterns
+
+Meta-principles are cross-cutting design rules that apply across _many_ individual patterns in this catalog. They capture the hard-won constraints that distinguish a pattern that _looks like_ enforcement from one that _actually enforces reliably_.
+
+These are not checklist items — they are standards for how patterns are written, tested, and delivered. Pattern authors and template maintainers should treat violations as bugs. Every pattern template under `templates/patterns/<id>/README.md` ends with a footer listing which of these principles the template obeys (see [Pattern-template footer convention](#pattern-template-footer-convention) at the end of this document).
+
+## Table of contents
+
+- [`mp-adversarial-proof-required`](#mp-adversarial-proof-required) — invariants must prove they catch regressions
+- [`mp-churn-bait-discipline`](#mp-churn-bait-discipline) — lock identifiers, never prose
+- [`mp-committed-proof-artifacts`](#mp-committed-proof-artifacts) — material claims ship as diffable manifests
+- [`mp-defense-in-depth`](#mp-defense-in-depth) — pair shift-left gates with runtime gates
+- [`mp-point-in-time-structural-claims`](#mp-point-in-time-structural-claims) — structural claims are verified-at-commit, not eternal
+- [`mp-authoritative-contract-file`](#mp-authoritative-contract-file) — one source of truth per shared number
+- [`mp-enforce-helpers-over-primitives`](#mp-enforce-helpers-over-primitives) — block the primitive, not just the mistake
+- [`mp-allowlist-over-blocklist`](#mp-allowlist-over-blocklist) — security surfaces default to closed
+
+---
+
+## `mp-adversarial-proof-required`
+
+**Any invariant-asserting test MUST ship with adversarial negative tests proving it catches the regression case. Without proof-of-catch, "enforcement" is unverified.**
+
+### Why
+
+A test that _looks like_ it enforces something but has no adversarial test is indistinguishable from a test that passes trivially. Reviewers cannot tell whether the assertion actually bites. Experience shows that such tests drift silently over time — broadened assertions, try/except swallowing, permissive matchers — and nobody notices until the defect class returns in production.
+
+### How to apply
+
+For every check that asserts an invariant (parity test, ratchet gate, rule-disable guardrail, schema conformance test), ship at least two additional tests alongside the check itself:
+
+1. **Fabricated-regression test** — deliberately construct the exact regression the check is supposed to catch and verify the check fails.
+2. **Removed-correctness test** — remove or weaken the condition the check relies on and verify the check fails.
+
+Both should live in the same test file as the check and reference it by name so the linkage is obvious.
+
+### Patterns governed
+
+- `lcp-parity-doc-coverage-test` — must prove it catches both a "fabricated new gate without doc cite" and a "removed cite for an existing gate"
+- Every `p-*` persistence parity test
+- Every `sec-rule-disable-*` guardrail
+- Every `td-*` ratchet gate
+
+---
+
+## `mp-churn-bait-discipline`
+
+**Parity and drift tests lock _canonical identifiers_ only — never prose, row counts, link shapes, or wording. Extending beyond canonical identifiers turns tests into churn-bait; consumers will remove them.**
+
+### Why
+
+Parity tests survive only if their lock surface is both _load-bearing_ (catches real defects) and _stable under editorial churn_ (doesn't fail on wording tweaks, reorg, or link updates). Prose-locking tests fail both criteria: wording shifts constantly, so the test fires on every minor doc edit, training reviewers to bypass it. Once the bypass habit forms, the test provides no signal and gets removed. Identifier presence, by contrast, shifts only when code structure actually changes — making it a high-signal, low-noise lock.
+
+### How to apply
+
+When writing a parity test between a code surface and a doc surface:
+
+- **Lock:** canonical identifier presence — function name, command name, gate name, or rule ID appears somewhere in the doc.
+- **Do NOT lock:** surrounding prose, adjacent rows, link text, formatting, section ordering, wording style, or bullet counts.
+
+Every pattern template that ships a parity test must carry this constraint verbatim in its README. Consumers need to see the discipline, not just inherit it silently — otherwise the next person who extends the test will reach past the intended scope.
+
+### Patterns governed
+
+- `lcp-parity-doc-coverage-test`
+- Any future test that asserts equivalence between a code inventory and a doc inventory
+
+---
+
+## `mp-committed-proof-artifacts`
+
+**Any claim that is hard to verify by code inspection alone — disabled-rule safety, subprocess-allowlist coverage, fundamental-table membership, rule-disable compensating controls — should be backed by a committed JSON manifest that is diffable in PR and exact-match-checked on every run.**
+
+### Why
+
+Some claims can't be checked with a single grep or a simple AST walk: "every call site of X is covered by a compensating control," "every disabled rule still has a valid justification." Without a materialized manifest, the claim lives only in reviewer memory — it drifts silently as new call sites appear.
+
+A committed proof artifact makes the claim _concrete_, _diffable in PR_, and _machine-checkable on every run_. New call sites fail the exact-match check and force the author to either update the manifest (with justification) or change the code.
+
+### How to apply
+
+- Ship a `.<claim>-audit.json` (or similar) at repo root.
+- Include enough context per entry for review: file path, line, kind of use, why it's acceptable.
+- CI verifies the manifest matches reality _exactly_ — neither a superset nor a subset. Additions require explicit manifest updates; removals require removing the entry.
+- Generator + verifier live in the repo as committed scripts, not in external tooling.
+
+### Patterns governed
+
+- `sec-rule-disable-proof-artifact`
+- `sec-subprocess-allowlist`
+- `td-test-floor-contract` (same pattern applied to test-count commitments)
+
+---
+
+## `mp-defense-in-depth`
+
+**Where feasible, pair a shift-left gate (PR-time parity test) with a runtime gate (connect-time / request-time check). They catch the same defect class at different costs and compensate for each other's blind spots.**
+
+### Why
+
+Shift-left gates (parity tests, ratchet checks) catch defects in PR CI. That's the cheapest fix point. But they depend on the test suite actually running correctly — if a harness change disables them silently, the gate stops firing. A runtime check catches the same defect class when real code paths exercise it, guaranteeing detection even when the PR-time gate was bypassed.
+
+Neither gate alone is sufficient: shift-left may miss an accidentally-disabled test; runtime may only fire once the bad state reaches production. Together they cover each other's failure modes.
+
+### How to apply
+
+For any defect class with both a shift-left opportunity and a runtime opportunity, ship both:
+
+- **Shift-left:** static or test-time check on the PR.
+- **Runtime:** an assertion or validation at the relevant boundary (DB connect, HTTP request entry, module import).
+
+Design the runtime check to fail loud — exit code, exception, or alert — not to silently recover and continue in a degraded state.
+
+### Patterns governed
+
+- `p-schema-migration-parity` (shift-left) paired with `p-required-tables-runtime-check` (runtime)
+- Any future pattern where both gates are available
+
+---
+
+## `mp-point-in-time-structural-claims`
+
+**Any structural claim in a pattern doc — counts, file lists, identifier inventories — is _verified at the time of writing_, not an eternal guarantee. Pattern docs state this explicitly and instruct implementers to re-verify before acting.**
+
+### Why
+
+Pattern docs accumulate specifics over time: "there are 38 gates in the preflight runner," "the parity doc has 82 rows." These numbers help readers calibrate but are _snapshots_. Branches advance; scripts get refactored. If a pattern doc reads as authoritative-forever and an implementer acts on a stale count, the resulting work is wrong.
+
+### How to apply
+
+- When a pattern doc states a structural count or inventory, stamp it: include the commit SHA (or date) at which it was verified.
+- Include an explicit instruction to re-verify: "re-run the AST walk against HEAD before writing any code."
+- Prefer describing _the shape of what you'll find_ over _the specific numbers you'll find_: "iterate every `CommandSpec` call site" is more durable than "there are 38 `CommandSpec` calls."
+
+### Patterns governed
+
+- Every pattern README (forthcoming under `templates/patterns/<id>/`)
+- Any future pattern doc that makes a structural claim
+
+---
+
+## `mp-authoritative-contract-file`
+
+**Where a number or invariant is shared across multiple sites — CI workflow, local preflight, ratchet gate — store it in a single contract JSON with an `authority` field pointing at the canonical producer. No hardcoded integers duplicated across files.**
+
+### Why
+
+Magic numbers duplicated across three files drift. CI reads one, local preflight reads another, the ratchet gate reads a third — and over time they disagree. The disagreement shows up as "CI passes but local fails" or "local passes but CI fails," both of which erode trust in the entire verification system.
+
+A single contract JSON with a documented authority ends the drift: every consumer reads from the same file, and the file names its canonical producer so anyone who wants to change the number knows who's responsible.
+
+### How to apply
+
+- Store the shared value in a JSON file at repo root (e.g., `.test-floor-contract.json`).
+- Include an `authority` field pointing at the producer code (e.g., `"authority": "scripts.check_ratchet_bump.collect_snapshot"`).
+- Every consumer reads from this file — no inline constants.
+- The producer writes to this file — nowhere else does.
+- CI verifies the file was actually regenerated (staleness check) when the producer's inputs changed.
+
+### Patterns governed
+
+- `td-test-floor-contract`
+- `td-coverage-ratchet` (via the floor formula)
+- Any future pattern sharing a threshold across multiple call sites
+
+---
+
+## `mp-enforce-helpers-over-primitives`
+
+**When a helper exists to make an operation safe, CI must forbid direct use of the underlying primitive. The helper's existence alone is not enough — the primitive must be blocked.**
+
+### Why
+
+A helper makes it _easy_ to do the safe thing; blocking the primitive makes it _impossible_ to accidentally do the unsafe thing. "We have a helper" plus "direct use of the primitive is still legal" degrades into "most of the codebase uses the helper but a few places forgot." Those forgotten places are where the vulnerability lives.
+
+### How to apply
+
+- When introducing a helper (e.g., a pagination-token wrapper, a crypto wrapper, a subprocess wrapper), pair it with a CI gate that forbids direct use of the underlying primitive.
+- Grep or AST-check for the primitive; allowlist only the helper's internal implementation.
+- Keep the helper opinionated — it should be obvious when a caller reaches around it.
+
+### Patterns governed
+
+- `sec-helper-enforcement`
+- Any future pattern that wraps a dangerous primitive
+
+---
+
+## `mp-allowlist-over-blocklist`
+
+**For security-sensitive surfaces — subprocess commands, CI-runnable actions, dependency sources — enumerate known-good and deny the rest. Blocklists of known-bad are unbounded and cannot be complete.**
+
+### Why
+
+Blocklists encode what you already know is dangerous. The gap — things that are dangerous and you don't know yet — is where attacks live. Allowlists flip the burden: new actions require an explicit review, catching both novel attacks and legitimate expansions.
+
+### How to apply
+
+- Identify the security surface (subprocess commands, GitHub Actions, npm registry sources, etc.).
+- Enumerate known-good entries in a committed allowlist file.
+- CI gate rejects any entry not in the allowlist.
+- Keep the allowlist compact; make additions visible in PR review.
+
+### Patterns governed
+
+- `sec-subprocess-allowlist`
+- Any future pattern gating a security-sensitive surface
+
+---
+
+## Pattern-template footer convention
+
+Every template under `templates/patterns/<id>/README.md` ends with a standard footer of the form:
+
+```markdown
+## Design principles this template obeys
+
+This pattern follows: `mp-adversarial-proof-required`, `mp-churn-bait-discipline`, `mp-committed-proof-artifacts` — see [Meta-Principles](../../patterns/meta-principles.md) for context.
+```
+
+A P2 CI gate verifies this footer exists in every pattern-template README. Missing footers fail the gate so meta-principles can't rot into ignored prose as the template count grows.

--- a/docs/patterns/meta-principles.md
+++ b/docs/patterns/meta-principles.md
@@ -215,7 +215,14 @@ Every template under `templates/patterns/<id>/README.md` ends with a standard fo
 ```markdown
 ## Design principles this template obeys
 
-This pattern follows: `mp-adversarial-proof-required`, `mp-churn-bait-discipline`, `mp-committed-proof-artifacts` — see [Meta-Principles](../../patterns/meta-principles.md) for context.
+This pattern follows: `mp-adversarial-proof-required`, `mp-churn-bait-discipline`, `mp-committed-proof-artifacts` — see [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.
 ```
 
-A P2 CI gate verifies this footer exists in every pattern-template README. Missing footers fail the gate so meta-principles can't rot into ignored prose as the template count grows.
+The relative path resolves from `templates/patterns/<id>/README.md` up three levels to the repo root, then into `docs/patterns/meta-principles.md`. The P2 CI gate (`scripts/verify-pattern-footers.ts`) runs on every `npm run test` and enforces:
+
+- the footer section is present,
+- at least one `mp-*` principle is cited,
+- every cited `mp-*` ID exists as a heading in this doc (typos fail the gate),
+- any template citing `mp-churn-bait-discipline` carries a "Scope discipline" anchor in its README.
+
+Adding a new principle here (as a new `## \`mp-xyz\`` section) makes it immediately citable — the gate parses the authoritative set from this doc.

--- a/instructions.csharp-dotnet.github-actions.md
+++ b/instructions.csharp-dotnet.github-actions.md
@@ -381,31 +381,31 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Schema/Migration Parity Test
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
 
 ### Migration DDL Byte-Parity
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
 
 ### Required-Tables Runtime Check
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
 
 ### Schema Version Seed Monotonic
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
 
 ### Per-Migration Test Coverage
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 

--- a/instructions.csharp-dotnet.github-actions.md
+++ b/instructions.csharp-dotnet.github-actions.md
@@ -492,3 +492,87 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
 - Consider adding victory-gates.md if applicable.
+
+### Patch Coverage Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.
+
+### Zero-Skips Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.
+
+### Platform-Conditional Test Collection Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.
+
+### Canonical Runtime Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.
+
+### Subprocess-Isolated Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.
+
+### Shallow-Clone Marker-Scan Determinism
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.
+
+### Generated-Artifact Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.
+
+### Breaking-Change Marker Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.
+
+### Cross-Platform Test-Count Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.
+
+### Rule-Disable Compensating Guardrail
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.
+
+### Helper-Over-Primitive Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.
+
+### CLI Reference Drift Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.
+
+### Per-Subcommand Help Snapshots
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.
+
+### Claude Code Hook Dispatch
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- .claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.

--- a/instructions.csharp-dotnet.github-actions.md
+++ b/instructions.csharp-dotnet.github-actions.md
@@ -7,28 +7,50 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ## Core Requirements
 
+### Git Attributes (Line Endings)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.
+- Ensure .gitattributes exists in the repository.
+- Consider adding .editorconfig if applicable.
+
+### CRLF Detection in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \r characters. Detect this before running deeper CI steps.
+- Detect CRLF in shell scripts and CI configuration files. C# source files can tolerate CRLF but shell scripts cannot.
+
 ### Git and Docker Ignore Files
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
 - Consider adding .dockerignore if applicable.
-- Use the official github/gitignore VisualStudio/.NET template. .dockerignore must exclude bin/, obj/, .vs/, \*.user, and similar local/build artifacts.
+- Use the official github/gitignore VisualStudio/.NET template. .dockerignore must exclude bin/, obj/, .vs/, *.user, and similar local/build artifacts.
 
 ### Linting
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Run static code linting to enforce consistency and catch common issues early.
 - Ensure .editorconfig exists in the repository.
 - Consider adding Directory.Build.props if applicable.
-- Define a `lint` script or equivalent command.
 - Enable analyzers or style rules for the solution and review warnings regularly; enforce stricter rules on new code.
 
 ### Unit Test Runner
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Provide a deterministic unit test framework with a single command to run all tests.
-- Consider adding \*.Tests.csproj if applicable.
+- Consider adding *.Tests.csproj if applicable.
 - Group unit tests into dedicated test projects and keep them independent from external services.
 
 ### Containerization (Docker / Docker Compose)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
 - Ensure Dockerfile exists in the repository.
@@ -37,52 +59,140 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.
+- Ensure *.csproj exists in the repository.
+- Consider adding GitVersion.yml, Directory.Build.props, CHANGELOG.md if applicable.
+- Define a `release` script or equivalent command.
+
+### Version Guard (Automated Releases)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.
+- Consider adding Directory.Build.props, *.csproj, VERSION if applicable.
+
+### Release Artifact Formatter Exclusion
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.
+
+### Unified Release Workflow
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.
+- Consider adding GitVersion.yml, Directory.Build.props if applicable.
+- Define a `release` script or equivalent command.
+
+### Release Hook Bypass
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.
+- Release pipelines should skip local hooks. If using Lefthook, set LEFTHOOK=0. Rely on CI gates for all validation.
 
 ### Commit Linting
 
-- Enforce structured commit messages such as Conventional Commits.
-- Document your commit convention and wire up a helper tool so contributors can easily follow it.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.
+- Define a `commitlint` script or equivalent command.
+- Document your Conventional Commit convention and enforce it via commit-msg hooks and CI so release tooling can compute versions deterministically.
 
 ### Unit Test Reporter / Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Enable coverage collection for test projects and publish reports in a human-friendly format from CI.
 
 ### CI Quality Gates
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Ensure CI runs analyzers, tests, build, and packaging or container checks before changes can be merged.
 
 ### Code Formatter
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Use .editorconfig and dotnet-format to keep C# style consistent across contributors.
 
 ### Pre-Commit Hooks
 
-- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
-- Configure Lefthook or similar to run formatting and basic checks on staged files before commits.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).
+
+### Hook/CI Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.
+- Define a verify target (make verify or dotnet cake verify) that both hooks and CI invoke. Keep verification logic in one place.
+
+### Pre-commit Secret Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.
+- Add gitleaks to pre-commit hooks via Lefthook. Scan staged changes before commits.
 
 ### Type Checking
 
-- Use static type checking to catch errors before runtime and enforce strictness on new code.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.
 - Ensure .editorconfig exists in the repository.
 - Consider adding Directory.Build.props if applicable.
-- Define a `typecheck` script or equivalent command.
 
 ### Dependency Management & Vulnerability Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
 - Consider adding packages.lock.json if applicable.
 - Enable package lock files and use vulnerability scanning to track and remediate high-risk dependencies.
 
+### Deterministic & Hermetic Builds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.
+- Consider adding packages.lock.json, global.json if applicable.
+- Enable packages.lock.json and use locked restore. Pin SDK versions via global.json and pin base images in Dockerfiles.
+
+### Provenance & Security Metadata
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.
+- Consider adding SECURITY.md, .github/workflows/codeql.yml if applicable.
+- Generate SBOM/provenance for NuGet and container artifacts, enable secret scanning, and sign tags/commits for critical repos.
+
+### CI Templates & Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.
+- Define a `ci` script or equivalent command.
+- Use shared CI templates for build/test/pack/release stages to standardize across .NET repos.
+
 ### Runtime Version Specification
 
-- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.
 - Consider adding global.json if applicable.
 
 ### Documentation Standards
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
 - Ensure README.md exists in the repository.
@@ -91,36 +201,210 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Repository Governance
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
 - Ensure LICENSE exists in the repository.
 - Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
 - Document contribution expectations and ensure legal and code-of-conduct policies are easy to find.
 
+### Canonical Verify Entrypoint
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.
+- Define 'make verify' or 'dotnet cake verify' that runs all checks. Both hooks and CI use this single entrypoint with stage-appropriate flags.
+
+### Config File Authority Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.
+
+### Explicit Skip Paths
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.
+- Use .editorconfig file globs to exclude generated code from analysis. Document exclusions with comments.
+
+### Hook Exit-Code Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
+
 ## Recommended Practices
 
+### Dependency Update Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+
+### Dependency Architecture Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Consider adding NsDepCop.config.nsdepcop if applicable.
+- NsDepCop enforces namespace dependency rules via config file. ArchUnitNET uses test code for architectural assertions.
+
 ### Integration Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
 - Create dedicated integration test projects that exercise real infrastructure or service boundaries where appropriate.
 
 ### Performance Baselines
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
 - Use BenchmarkDotNet or similar to track performance of critical methods or endpoints over time.
 
 ### Complexity Analysis
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
 - Use code metrics or Sonar analysis to flag overly complex methods and refactor them over time.
 
 ### Accessibility Auditing
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
 - Apply accessibility tooling to ASP.NET or Blazor front-ends and review issues alongside functional testing.
+
+### AI Drift Detection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.
+- Use Verify library or custom comparison tests to detect AI output drift. Run nightly to catch model-side changes that don't show up in code diffs.
+
+### AI Output Schema Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.
+
+### AI Golden Contract Tests
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.
+- Use Verify for golden file testing of AI outputs. Ensure AI-generated code respects namespace conventions and doesn't modify protected files.
+
+### AI Adversarial & Safety Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.
+
+### AI Provenance & Audit Logging
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.
+- Use structured logging to capture AI call provenance. Include model version, prompt hash, and parameters in log context.
+
+### Autonomous Agent Invariants
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.
+- Ensure INVARIANTS.md exists in the repository.
+- Document invariants with verification commands like 'dotnet test', 'dotnet format --verify-no-changes', 'dotnet build' for autonomous validation.
+
+### Local/CI Parity Invariants Document
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.
+
+### Parity Doc Coverage Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.
+
+### Tiered Hook Model
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.
+
+### Hook Dispatcher Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.
+
+### Pre-Push Preflight Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'
+
+### Fail-Fast Hook Setup Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.
+
+### Schema/Migration Parity Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
+
+### Migration DDL Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
+
+### Required-Tables Runtime Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
+
+### Schema Version Seed Monotonic
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
+
+### Per-Migration Test Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 
 ## Optional Enhancements
 
 ### Observability (Logging & Error Handling)
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Standardize error handling and structured logging to make debugging and production monitoring easier.
 - Configure structured logging for your .NET services and ensure exceptions and key events are logged with useful context.
+
+### Agent Phase Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.
+- Consider adding phase-gates.md if applicable.
+- Define phase gates with .NET-specific verification (dotnet test, coverage reports, NuGet package publishing) and approval workflows.
+
+### Agent Victory Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
+- Consider adding victory-gates.md if applicable.

--- a/instructions.csharp-dotnet.github-actions.md
+++ b/instructions.csharp-dotnet.github-actions.md
@@ -234,6 +234,30 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
 
+### EditorConfig
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.
+
+### Zero-Warnings Lint Discipline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.
+
+### Full-History Secret Scan in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.
+
+### semantic-release Integration
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.
+
 ## Recommended Practices
 
 ### Dependency Update Automation
@@ -384,6 +408,66 @@ This document provides high-level guidance for an autonomous coding agent to bri
 > **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
+
+### Justified Lint Ignores
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.
+
+### Coverage Ratchet (Raise-Only)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.
+
+### Tiered Coverage Thresholds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.
+
+### Coverage Delta Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.
+
+### Test Floor Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.
+
+### Ratchet Bump Equality Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.
+
+### Threshold Change Marker Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.
+
+### Commit-Subject Marker Bypass Convention
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.
+
+### Rule-Disable Proof Artifact
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.
+
+### Suppression Audit with Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.
 
 ## Optional Enhancements
 

--- a/instructions.md
+++ b/instructions.md
@@ -233,6 +233,54 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
 
+### Package Manager Exclusivity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce a single package manager per repo via a preinstall script that exits non-zero if the wrong one is invoked. Combined with engine-strict, prevents lockfile drift and npm/pnpm mixed installs that break reproducibility.
+
+### Lockfile Discipline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate fails on the presence of any unauthorized lockfile — e.g., a package-lock.json in a pnpm repo, or a yarn.lock in an npm repo. Companion to package-manager exclusivity; catches wrong-tool installs that slip past the preinstall guard.
+
+### packageManager Field
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- package.json declares a pinned `packageManager` field (e.g., "pnpm@9.15.0") that Corepack and CI can use to auto-select the correct tool + version. Keeps the package-manager exclusivity guard and engine pins aligned with one authoritative source.
+
+### EditorConfig
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.
+
+### engine-strict Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Set engine-strict=true in .npmrc (or equivalent) so the engines field in package.json becomes a hard install-time constraint, not advisory. Prevents 'works on my machine' drift from mismatched Node or package-manager versions.
+
+### Zero-Warnings Lint Discipline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.
+
+### Full-History Secret Scan in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.
+
+### semantic-release Integration
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.
+
 ## Recommended Practices
 
 ### Dependency Update Automation
@@ -378,6 +426,72 @@ This document provides high-level guidance for an autonomous coding agent to bri
 > **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
+
+### Justified Lint Ignores
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.
+
+### Coverage Ratchet (Raise-Only)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.
+
+### Tiered Coverage Thresholds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.
+
+### Coverage Delta Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.
+
+### Test Floor Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.
+
+### Ratchet Bump Equality Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.
+
+### Threshold Change Marker Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.
+
+### Commit-Subject Marker Bypass Convention
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.
+
+### Package-Manager Command Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate scans workflows, scripts, and configs for forbidden package-manager commands — e.g., 'npm install' or 'npm ci' in a pnpm-exclusive repo. Catches drift that the preinstall guard alone won't: workflow-file edits that bypass installs entirely.
+
+### Rule-Disable Proof Artifact
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.
+
+### Suppression Audit with Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.
 
 ## Optional Enhancements
 

--- a/instructions.md
+++ b/instructions.md
@@ -399,31 +399,31 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Schema/Migration Parity Test
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
 
 ### Migration DDL Byte-Parity
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
 
 ### Required-Tables Runtime Check
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
 
 ### Schema Version Seed Monotonic
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
 
 ### Per-Migration Test Coverage
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 

--- a/instructions.md
+++ b/instructions.md
@@ -1,13 +1,30 @@
 # Repository Standards Instructions
 
-> Auto-generated from `config/standards.typescript-js.github-actions.json`
+> Auto-generated from `config\standards.typescript-js.github-actions.json`
 > Stack: TypeScript / JavaScript | CI: github-actions
 
 This document provides high-level guidance for an autonomous coding agent to bring a repository into compliance with the defined standards.
 
 ## Core Requirements
 
+### Git Attributes (Line Endings)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.
+- Ensure .gitattributes exists in the repository.
+- Consider adding .editorconfig if applicable.
+
+### CRLF Detection in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \r characters. Detect this before running deeper CI steps.
+- Check for CRLF in .sh, .js, .ts, .json files early in CI. Use 'file' command or grep for \r to detect issues before they cause cryptic failures.
+
 ### Git and Docker Ignore Files
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
@@ -15,20 +32,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Linting
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure eslint.config.js exists in the repository.
-- Consider adding .eslintrc.js, .eslintrc.cjs, .eslintrc.json and others if applicable.
-- Define a `lint` script in package.json or equivalent.
+- Consider adding .prettierrc, prettier.config.js, prettier.config.cjs and others if applicable.
+- Define a `lint` script or equivalent command.
 - Treat new lint errors as CI failures; keep existing issues as warnings until addressed.
 
 ### Unit Test Runner
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
-- Define a `test` script in package.json or equivalent.
+- Define a `test` script or equivalent command.
 - Keep unit tests fast and deterministic; move slow or flaky tests into integration or E2E suites.
 
 ### Containerization (Docker / Docker Compose)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
 - Ensure Dockerfile exists in the repository.
@@ -37,47 +59,140 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.
+- Ensure package.json exists in the repository.
+- Consider adding VERSION, CHANGELOG.md if applicable.
+- Define a `release` script or equivalent command.
+
+### Version Guard (Automated Releases)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.
+- Ensure package.json exists in the repository.
+- Consider adding VERSION if applicable.
+
+### Release Artifact Formatter Exclusion
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.
+- Ensure .prettierignore exists in the repository.
+
+### Unified Release Workflow
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.
+- Consider adding CHANGELOG.md, VERSION if applicable.
+- Define a `release` script or equivalent command.
+
+### Release Hook Bypass
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.
 
 ### Commit Linting
 
-- Enforce structured commit messages such as Conventional Commits.
-- Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.
+- Define a `commitlint` script or equivalent command.
+- Enforce Conventional Commits via commit-msg hooks (e.g., Husky) and a CI job so versioning/changelog automation is deterministic.
 
 ### Unit Test Reporter / Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Collect coverage in lcov or similar format; use diff coverage so legacy gaps are visible but non-blocking.
 
 ### CI Quality Gates
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Expose a single npm script (e.g., `npm run ci`) that mirrors the CI pipeline so contributors can reproduce failures locally.
 
 ### Code Formatter
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Run Prettier in check mode in CI; auto-fix locally via pre-commit hooks or editor integration.
 
 ### Pre-Commit Hooks
 
-- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
-- Run ESLint and Prettier on staged files and enforce commit message format via commit-msg hooks.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).
+
+### Hook/CI Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.
+- Define a `verify` script or equivalent command.
+
+### Pre-commit Secret Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.
+- Add gitleaks or detect-secrets to pre-commit hooks. Scan only staged changes for speed. Configure allowlists for false positives in .gitleaks.toml.
 
 ### Type Checking
 
-- Use static type checking to catch errors before runtime and enforce strictness on new code.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.
 - Ensure tsconfig.json exists in the repository.
-- Define a `typecheck` script in package.json or equivalent.
-- Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.
+- Define a `typecheck` script or equivalent command.
 
 ### Dependency Management & Vulnerability Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
 - Consider adding package-lock.json, pnpm-lock.yaml, yarn.lock if applicable.
 - Require a lockfile for reproducible installs and pin Node.js/tooling versions; block merges on new high-severity vulnerabilities.
 
+### Deterministic & Hermetic Builds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.
+- Consider adding .nvmrc, .tool-versions if applicable.
+
+### Provenance & Security Metadata
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.
+- Consider adding SECURITY.md, .github/workflows/codeql.yml if applicable.
+- Generate SBOM/provenance for npm and container artifacts, enable secret scanning, and sign tags/commits for protected branches.
+
+### CI Templates & Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.
+- Define a `ci` script or equivalent command.
+- Use shared CI templates for lint/test/build/release stages and keep repo-specific overrides minimal.
+
+### Runtime Version Specification
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.
+- Ensure package.json exists in the repository.
+
 ### Documentation Standards
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
 - Ensure README.md exists in the repository.
@@ -86,36 +201,203 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Repository Governance
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
 - Ensure LICENSE exists in the repository.
 - Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
 - Use an SPDX license identifier in package.json and describe review expectations, tests, and docs requirements in CONTRIBUTING.md.
 
+### Canonical Verify Entrypoint
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.
+- Define a `verify` script or equivalent command.
+
+### Config File Authority Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.
+
+### Explicit Skip Paths
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.
+
+### Hook Exit-Code Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
+
 ## Recommended Practices
 
+### Dependency Update Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+
+### Dependency Architecture Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Define forbidden imports, layer rules, and circular dependency bans. Run in CI as blocking check.
+
 ### Integration Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
 - Use Supertest for HTTP APIs and Playwright or similar tools for end-to-end flows; keep integration suites slower but reliable.
 
 ### Performance Baselines
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
 - Run Lighthouse CI for web apps and basic Node benchmarks on critical endpoints; schedule runs or limit to key branches to keep CI fast.
 
 ### Complexity Analysis
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
 - Warn on overly complex functions and methods; fail CI only when new or modified code exceeds thresholds.
 
 ### Accessibility Auditing
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
 - Run accessibility checks against key pages or components in CI; fail on critical violations while treating minor issues as warnings initially.
+
+### AI Drift Detection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.
+
+### AI Output Schema Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.
+
+### AI Golden Contract Tests
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.
+
+### AI Adversarial & Safety Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.
+
+### AI Provenance & Audit Logging
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.
+
+### Autonomous Agent Invariants
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.
+- Ensure INVARIANTS.md exists in the repository.
+
+### Local/CI Parity Invariants Document
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.
+
+### Parity Doc Coverage Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.
+
+### Tiered Hook Model
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.
+
+### Hook Dispatcher Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.
+
+### Pre-Push Preflight Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'
+
+### Fail-Fast Hook Setup Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.
+
+### Schema/Migration Parity Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
+
+### Migration DDL Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
+
+### Required-Tables Runtime Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
+
+### Schema Version Seed Monotonic
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
+
+### Per-Migration Test Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 
 ## Optional Enhancements
 
 ### Observability (Logging & Error Handling)
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Standardize error handling and structured logging to make debugging and production monitoring easier.
 - Adopt structured JSON logging with correlation IDs and send logs to a centralized sink in production.
+
+### Agent Phase Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.
+- Consider adding phase-gates.md if applicable.
+
+### Agent Victory Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
+- Consider adding victory-gates.md if applicable.

--- a/instructions.md
+++ b/instructions.md
@@ -515,3 +515,105 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
 - Consider adding victory-gates.md if applicable.
+
+### Split TypeScript Configs
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Separate tsconfig files for typecheck (strict, bundler resolution), build (emit, CommonJS or ESM as appropriate), tests, and type-tests. A guard test locks module/moduleResolution per config so tsc cannot silently overwrite an IIFE bundle with a CommonJS one, or vice versa.
+
+### No any / Any Types
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.
+
+### Patch Coverage Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.
+
+### Zero-Skips Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.
+
+### Platform-Conditional Test Collection Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.
+
+### Canonical Runtime Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.
+
+### Subprocess-Isolated Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.
+
+### LCOV Partial-Branch Ratchet
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- LCOV partial-branches baseline with a locked-zero files list. CI fails if a file on the locked-zero list develops any partial branches. Catches a class of untested conditional branches that line and statement coverage alone do not detect.
+
+### Shallow-Clone Marker-Scan Determinism
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.
+
+### Generated-Artifact Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.
+
+### Breaking-Change Marker Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.
+
+### Cross-Platform Test-Count Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.
+
+### Rule-Disable Compensating Guardrail
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.
+
+### Helper-Over-Primitive Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.
+
+### CLI Reference Drift Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.
+
+### Per-Subcommand Help Snapshots
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.
+
+### Claude Code Hook Dispatch
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- .claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.

--- a/instructions.python.github-actions.md
+++ b/instructions.python.github-actions.md
@@ -7,7 +7,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ## Core Requirements
 
+### Git Attributes (Line Endings)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.
+- Ensure .gitattributes exists in the repository.
+- Consider adding .editorconfig if applicable.
+- Python files should use LF endings for cross-platform compatibility. Mark *.py as eol=lf in .gitattributes. Shebang scripts fail with CRLF.
+
+### CRLF Detection in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \r characters. Detect this before running deeper CI steps.
+- Python shebang scripts fail with CRLF. Check all .py and .sh files for CRLF before running pytest or other Python tools.
+
 ### Git and Docker Ignore Files
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
@@ -15,20 +33,22 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Linting
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure pyproject.toml exists in the repository.
-- Consider adding ruff.toml, .flake8 if applicable.
-- Define a `lint` script or equivalent command.
 - Configure a primary linter (such as ruff) and keep rules focused on catching real issues without overwhelming developers.
 
 ### Unit Test Runner
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
-- Define a `test` script or equivalent command.
 - Organize unit tests under a tests/ directory and avoid real network or database calls in this layer.
 
 ### Containerization (Docker / Docker Compose)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
 - Ensure Dockerfile exists in the repository.
@@ -37,36 +57,97 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.
+- Ensure pyproject.toml exists in the repository.
+- Consider adding VERSION, CHANGELOG.md if applicable.
+- Define a `release` script or equivalent command.
+
+### Version Guard (Automated Releases)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.
+- Ensure pyproject.toml exists in the repository.
+- Consider adding setup.cfg, setup.py, VERSION if applicable.
+- Block manual edits to version fields in pyproject.toml or setup.cfg when automated release tooling computes versions from commit history.
+
+### Release Artifact Formatter Exclusion
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.
+
+### Unified Release Workflow
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.
+- Consider adding CHANGELOG.md, VERSION if applicable.
+- Define a `release` script or equivalent command.
+
+### Release Hook Bypass
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.
+- Set PRE_COMMIT_ALLOW_NO_CONFIG=1 or SKIP=all to bypass pre-commit hooks in release automation. CI gates already validated.
 
 ### Commit Linting
 
-- Enforce structured commit messages such as Conventional Commits.
-- Standardize commit messages using commitizen or a similar helper and document the required types and scopes.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.
+- Define a `commitlint` script or equivalent command.
+- Standardize Conventional Commits using commitizen or commitlint with commit-msg hooks plus CI so changelog generation is deterministic.
 
 ### Unit Test Reporter / Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Configure coverage reporting for your test suite and surface summary metrics in CI.
 
 ### CI Quality Gates
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Ensure CI runs linting, type checking (if used), tests, and packaging or container checks for Python services before merging.
 
 ### Code Formatter
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Use black (or an equivalent opinionated formatter) and treat its output as the single source of truth for code style.
 
 ### Pre-Commit Hooks
 
-- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
-- Use pre-commit to run ruff, black, and optionally mypy on staged files before committing.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).
+
+### Hook/CI Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.
+- Define a verify target (make verify, tox -e lint, or nox -s lint) that both pre-commit and CI invoke. Pin tool versions in pyproject.toml.
+
+### Pre-commit Secret Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.
+- Add detect-secrets or gitleaks to .pre-commit-config.yaml. Use detect-secrets audit to manage baselines.
 
 ### Type Checking
 
-- Use static type checking to catch errors before runtime and enforce strictness on new code.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.
 - Ensure pyproject.toml exists in the repository.
 - Consider adding mypy.ini if applicable.
 - Define a `typecheck` script or equivalent command.
@@ -74,17 +155,46 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Dependency Management & Vulnerability Scanning
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
 - Consider adding requirements.txt, Pipfile.lock, poetry.lock if applicable.
 - Pin dependency versions and routinely scan for vulnerabilities, prioritizing fixes for critical and high-severity issues.
 
+### Deterministic & Hermetic Builds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.
+- Consider adding .python-version, .tool-versions if applicable.
+
+### Provenance & Security Metadata
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.
+- Consider adding SECURITY.md, .github/workflows/codeql.yml if applicable.
+- Generate SBOM/provenance for PyPI and container artifacts, enable secret scanning, and sign tags/commits for critical repos.
+
+### CI Templates & Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.
+- Define a `ci` script or equivalent command.
+- Use shared CI templates for lint/test/typecheck/release stages to standardize across Python repos.
+
 ### Runtime Version Specification
 
-- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.
 - Ensure pyproject.toml exists in the repository.
 - Consider adding .python-version if applicable.
 
 ### Documentation Standards
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
 - Ensure README.md exists in the repository.
@@ -93,36 +203,211 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Repository Governance
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
 - Ensure LICENSE exists in the repository.
 - Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
 - Spell out contributor responsibilities for tests, documentation, and review so expectations are clear for Python-focused teams.
 
+### Canonical Verify Entrypoint
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.
+- Define 'make verify' or 'tox -e verify' that runs ruff, black --check, mypy, and pytest. All stages use this entrypoint.
+
+### Config File Authority Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.
+
+### Explicit Skip Paths
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.
+
+### Hook Exit-Code Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
+
 ## Recommended Practices
 
+### Dependency Update Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Renovate supports pyproject.toml, requirements.txt, Pipfile, poetry.lock. For AzDO: self-hosted Renovate or schedule-triggered pipeline.
+
+### Dependency Architecture Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Consider adding pyproject.toml, .importlinter if applicable.
+- Configure [tool.importlinter] in pyproject.toml OR use standalone .importlinter file. pydeps is visualization-only.
+
 ### Integration Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
 - Separate integration tests from unit tests, using fixtures to handle databases, services, or other external systems.
 
 ### Performance Baselines
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
 - Use simple benchmarks or profiling runs to characterize bottlenecks and watch for regressions in critical workflows.
 
 ### Complexity Analysis
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
 - Use radon or similar tools to track complexity of Python functions and keep new code within acceptable limits.
 
 ### Accessibility Auditing
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
 - Use headless browser-based tools to scan Python-backed web UIs for accessibility issues on high-traffic routes.
+
+### AI Drift Detection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.
+
+### AI Output Schema Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.
+
+### AI Golden Contract Tests
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.
+- Use pytest with syrupy for snapshot testing AI outputs. Test that generated code follows project conventions and respects forbidden paths.
+
+### AI Adversarial & Safety Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.
+- Use hypothesis for property-based testing of AI input handling. Test prompt injection, output sanitization, and data boundary enforcement.
+
+### AI Provenance & Audit Logging
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.
+- Log AI provenance using structlog or MLflow tracking. For ML models, also track training data version and model artifact hash.
+
+### Autonomous Agent Invariants
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.
+- Ensure INVARIANTS.md exists in the repository.
+- List invariants with commands like 'pytest', 'ruff check', 'mypy' that agents can execute to verify repository state.
+
+### Local/CI Parity Invariants Document
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.
+
+### Parity Doc Coverage Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.
+
+### Tiered Hook Model
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.
+
+### Hook Dispatcher Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.
+
+### Pre-Push Preflight Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'
+
+### Fail-Fast Hook Setup Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.
+
+### Schema/Migration Parity Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
+
+### Migration DDL Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
+
+### Required-Tables Runtime Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
+
+### Schema Version Seed Monotonic
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
+
+### Per-Migration Test Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 
 ## Optional Enhancements
 
 ### Observability (Logging & Error Handling)
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Standardize error handling and structured logging to make debugging and production monitoring easier.
 - Use structured logging for Python services and ensure critical paths record enough context to debug issues after the fact.
+
+### Agent Phase Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.
+- Consider adding phase-gates.md if applicable.
+- Specify phase transitions with Python-specific checks (pytest results, wheel/sdist builds, PyPI publication) and approval processes.
+
+### Agent Victory Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
+- Consider adding victory-gates.md if applicable.
+- Document release readiness gates with Python-specific criteria (PyPI publishing, wheel distribution, dependency compatibility) and proof artifacts.

--- a/instructions.python.github-actions.md
+++ b/instructions.python.github-actions.md
@@ -235,6 +235,30 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
 
+### EditorConfig
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.
+
+### Zero-Warnings Lint Discipline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.
+
+### Full-History Secret Scan in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.
+
+### semantic-release Integration
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.
+
 ## Recommended Practices
 
 ### Dependency Update Automation
@@ -386,6 +410,66 @@ This document provides high-level guidance for an autonomous coding agent to bri
 > **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
+
+### Justified Lint Ignores
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.
+
+### Coverage Ratchet (Raise-Only)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.
+
+### Tiered Coverage Thresholds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.
+
+### Coverage Delta Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.
+
+### Test Floor Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.
+
+### Ratchet Bump Equality Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.
+
+### Threshold Change Marker Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.
+
+### Commit-Subject Marker Bypass Convention
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.
+
+### Rule-Disable Proof Artifact
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.
+
+### Suppression Audit with Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.
 
 ## Optional Enhancements
 

--- a/instructions.python.github-actions.md
+++ b/instructions.python.github-actions.md
@@ -383,31 +383,31 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Schema/Migration Parity Test
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
 
 ### Migration DDL Byte-Parity
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
 
 ### Required-Tables Runtime Check
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
 
 ### Schema Version Seed Monotonic
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
 
 ### Per-Migration Test Coverage
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 

--- a/instructions.python.github-actions.md
+++ b/instructions.python.github-actions.md
@@ -495,3 +495,99 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
 - Consider adding victory-gates.md if applicable.
 - Document release readiness gates with Python-specific criteria (PyPI publishing, wheel distribution, dependency compatibility) and proof artifacts.
+
+### No any / Any Types
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.
+
+### Patch Coverage Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.
+
+### Zero-Skips Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.
+
+### Platform-Conditional Test Collection Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.
+
+### Canonical Runtime Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.
+
+### Subprocess-Isolated Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.
+
+### Shallow-Clone Marker-Scan Determinism
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.
+
+### Generated-Artifact Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.
+
+### Breaking-Change Marker Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.
+
+### Cross-Platform Test-Count Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.
+
+### Rule-Disable Compensating Guardrail
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.
+
+### Subprocess Command Allowlist
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit an allowlist file (e.g., .subprocess-allowlist.json) enumerating repo-owned non-literal subprocess commands. A guardrail script verifies every subprocess call is either a string literal or appears in the allowlist. Compensates for globally-disabled subprocess-safety lint rules.
+
+### Helper-Over-Primitive Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.
+
+### CLI Reference Drift Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.
+
+### Per-Subcommand Help Snapshots
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.
+
+### Claude Code Hook Dispatch
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- .claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.

--- a/instructions.python.md
+++ b/instructions.python.md
@@ -235,6 +235,30 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
 
+### EditorConfig
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.
+
+### Zero-Warnings Lint Discipline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.
+
+### Full-History Secret Scan in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.
+
+### semantic-release Integration
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.
+
 ## Recommended Practices
 
 ### Dependency Update Automation
@@ -386,6 +410,66 @@ This document provides high-level guidance for an autonomous coding agent to bri
 > **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
+
+### Justified Lint Ignores
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.
+
+### Coverage Ratchet (Raise-Only)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.
+
+### Tiered Coverage Thresholds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.
+
+### Coverage Delta Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.
+
+### Test Floor Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.
+
+### Ratchet Bump Equality Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.
+
+### Threshold Change Marker Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.
+
+### Commit-Subject Marker Bypass Convention
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.
+
+### Rule-Disable Proof Artifact
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.
+
+### Suppression Audit with Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.
 
 ## Optional Enhancements
 

--- a/instructions.python.md
+++ b/instructions.python.md
@@ -7,7 +7,25 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ## Core Requirements
 
+### Git Attributes (Line Endings)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.
+- Ensure .gitattributes exists in the repository.
+- Consider adding .editorconfig if applicable.
+- Python files should use LF endings for cross-platform compatibility. Mark *.py as eol=lf in .gitattributes. Shebang scripts fail with CRLF.
+
+### CRLF Detection in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \r characters. Detect this before running deeper CI steps.
+- Python shebang scripts fail with CRLF. Check all .py and .sh files for CRLF before running pytest or other Python tools.
+
 ### Git and Docker Ignore Files
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
@@ -15,20 +33,22 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Linting
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure pyproject.toml exists in the repository.
-- Consider adding ruff.toml, .flake8 if applicable.
-- Define a `lint` script in package.json or equivalent.
 - Configure a primary linter (such as ruff) and keep rules focused on catching real issues without overwhelming developers.
 
 ### Unit Test Runner
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Consider adding pytest.ini, pyproject.toml, tests/ if applicable.
-- Define a `test` script in package.json or equivalent.
 - Organize unit tests under a tests/ directory and avoid real network or database calls in this layer.
 
 ### Containerization (Docker / Docker Compose)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
 - Ensure Dockerfile exists in the repository.
@@ -37,49 +57,144 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
-- Use a single source of truth for the package version and keep it aligned with SemVer and your release notes.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.
+- Ensure pyproject.toml exists in the repository.
+- Consider adding VERSION, CHANGELOG.md if applicable.
+- Define a `release` script or equivalent command.
+
+### Version Guard (Automated Releases)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.
+- Ensure pyproject.toml exists in the repository.
+- Consider adding setup.cfg, setup.py, VERSION if applicable.
+- Block manual edits to version fields in pyproject.toml or setup.cfg when automated release tooling computes versions from commit history.
+
+### Release Artifact Formatter Exclusion
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.
+
+### Unified Release Workflow
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.
+- Consider adding CHANGELOG.md, VERSION if applicable.
+- Define a `release` script or equivalent command.
+
+### Release Hook Bypass
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.
+- Set PRE_COMMIT_ALLOW_NO_CONFIG=1 or SKIP=all to bypass pre-commit hooks in release automation. CI gates already validated.
 
 ### Commit Linting
 
-- Enforce structured commit messages such as Conventional Commits.
-- Standardize commit messages using commitizen or a similar helper and document the required types and scopes.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.
+- Define a `commitlint` script or equivalent command.
+- Standardize Conventional Commits using commitizen or commitlint with commit-msg hooks plus CI so changelog generation is deterministic.
 
 ### Unit Test Reporter / Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Configure coverage reporting for your test suite and surface summary metrics in CI.
 
 ### CI Quality Gates
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Ensure CI runs linting, type checking (if used), tests, and packaging or container checks for Python services before merging.
 
 ### Code Formatter
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Use black (or an equivalent opinionated formatter) and treat its output as the single source of truth for code style.
 
 ### Pre-Commit Hooks
 
-- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
-- Use pre-commit to run ruff, black, and optionally mypy on staged files before committing.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).
+
+### Hook/CI Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.
+- Define a verify target (make verify, tox -e lint, or nox -s lint) that both pre-commit and CI invoke. Pin tool versions in pyproject.toml.
+
+### Pre-commit Secret Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.
+- Add detect-secrets or gitleaks to .pre-commit-config.yaml. Use detect-secrets audit to manage baselines.
 
 ### Type Checking
 
-- Use static type checking to catch errors before runtime and enforce strictness on new code.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.
 - Ensure pyproject.toml exists in the repository.
 - Consider adding mypy.ini if applicable.
-- Define a `typecheck` script in package.json or equivalent.
+- Define a `typecheck` script or equivalent command.
 - Adopt gradual typing with type hints and mypy, focusing first on critical modules and new code paths.
 
 ### Dependency Management & Vulnerability Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
 - Consider adding requirements.txt, Pipfile.lock, poetry.lock if applicable.
 - Pin dependency versions and routinely scan for vulnerabilities, prioritizing fixes for critical and high-severity issues.
 
+### Deterministic & Hermetic Builds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.
+- Consider adding .python-version, .tool-versions if applicable.
+
+### Provenance & Security Metadata
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.
+- Consider adding SECURITY.md, .github/workflows/codeql.yml if applicable.
+- Generate SBOM/provenance for PyPI and container artifacts, enable secret scanning, and sign tags/commits for critical repos.
+
+### CI Templates & Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.
+- Define a `ci` script or equivalent command.
+- Use shared CI templates for lint/test/typecheck/release stages to standardize across Python repos.
+
+### Runtime Version Specification
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.
+- Ensure pyproject.toml exists in the repository.
+- Consider adding .python-version if applicable.
+
 ### Documentation Standards
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
 - Ensure README.md exists in the repository.
@@ -88,36 +203,211 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Repository Governance
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
 - Ensure LICENSE exists in the repository.
 - Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
 - Spell out contributor responsibilities for tests, documentation, and review so expectations are clear for Python-focused teams.
 
+### Canonical Verify Entrypoint
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.
+- Define 'make verify' or 'tox -e verify' that runs ruff, black --check, mypy, and pytest. All stages use this entrypoint.
+
+### Config File Authority Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.
+
+### Explicit Skip Paths
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.
+
+### Hook Exit-Code Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
+
 ## Recommended Practices
 
+### Dependency Update Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+- Renovate supports pyproject.toml, requirements.txt, Pipfile, poetry.lock. For AzDO: self-hosted Renovate or schedule-triggered pipeline.
+
+### Dependency Architecture Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Consider adding pyproject.toml, .importlinter if applicable.
+- Configure [tool.importlinter] in pyproject.toml OR use standalone .importlinter file. pydeps is visualization-only.
+
 ### Integration Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
 - Separate integration tests from unit tests, using fixtures to handle databases, services, or other external systems.
 
 ### Performance Baselines
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
 - Use simple benchmarks or profiling runs to characterize bottlenecks and watch for regressions in critical workflows.
 
 ### Complexity Analysis
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
 - Use radon or similar tools to track complexity of Python functions and keep new code within acceptable limits.
 
 ### Accessibility Auditing
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
 - Use headless browser-based tools to scan Python-backed web UIs for accessibility issues on high-traffic routes.
+
+### AI Drift Detection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.
+
+### AI Output Schema Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.
+
+### AI Golden Contract Tests
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.
+- Use pytest with syrupy for snapshot testing AI outputs. Test that generated code follows project conventions and respects forbidden paths.
+
+### AI Adversarial & Safety Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.
+- Use hypothesis for property-based testing of AI input handling. Test prompt injection, output sanitization, and data boundary enforcement.
+
+### AI Provenance & Audit Logging
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.
+- Log AI provenance using structlog or MLflow tracking. For ML models, also track training data version and model artifact hash.
+
+### Autonomous Agent Invariants
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.
+- Ensure INVARIANTS.md exists in the repository.
+- List invariants with commands like 'pytest', 'ruff check', 'mypy' that agents can execute to verify repository state.
+
+### Local/CI Parity Invariants Document
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.
+
+### Parity Doc Coverage Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.
+
+### Tiered Hook Model
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.
+
+### Hook Dispatcher Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.
+
+### Pre-Push Preflight Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'
+
+### Fail-Fast Hook Setup Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.
+
+### Schema/Migration Parity Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
+
+### Migration DDL Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
+
+### Required-Tables Runtime Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
+
+### Schema Version Seed Monotonic
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
+
+### Per-Migration Test Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 
 ## Optional Enhancements
 
 ### Observability (Logging & Error Handling)
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Standardize error handling and structured logging to make debugging and production monitoring easier.
 - Use structured logging for Python services and ensure critical paths record enough context to debug issues after the fact.
+
+### Agent Phase Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.
+- Consider adding phase-gates.md if applicable.
+- Specify phase transitions with Python-specific checks (pytest results, wheel/sdist builds, PyPI publication) and approval processes.
+
+### Agent Victory Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
+- Consider adding victory-gates.md if applicable.
+- Document release readiness gates with Python-specific criteria (PyPI publishing, wheel distribution, dependency compatibility) and proof artifacts.

--- a/instructions.python.md
+++ b/instructions.python.md
@@ -383,31 +383,31 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Schema/Migration Parity Test
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
 
 ### Migration DDL Byte-Parity
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
 
 ### Required-Tables Runtime Check
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
 
 ### Schema Version Seed Monotonic
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
 
 ### Per-Migration Test Coverage
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 

--- a/instructions.python.md
+++ b/instructions.python.md
@@ -495,3 +495,99 @@ This document provides high-level guidance for an autonomous coding agent to bri
 - Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
 - Consider adding victory-gates.md if applicable.
 - Document release readiness gates with Python-specific criteria (PyPI publishing, wheel distribution, dependency compatibility) and proof artifacts.
+
+### No any / Any Types
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.
+
+### Patch Coverage Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.
+
+### Zero-Skips Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.
+
+### Platform-Conditional Test Collection Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.
+
+### Canonical Runtime Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.
+
+### Subprocess-Isolated Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.
+
+### Shallow-Clone Marker-Scan Determinism
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.
+
+### Generated-Artifact Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.
+
+### Breaking-Change Marker Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.
+
+### Cross-Platform Test-Count Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.
+
+### Rule-Disable Compensating Guardrail
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.
+
+### Subprocess Command Allowlist
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit an allowlist file (e.g., .subprocess-allowlist.json) enumerating repo-owned non-literal subprocess commands. A guardrail script verifies every subprocess call is either a string literal or appears in the allowlist. Compensates for globally-disabled subprocess-safety lint rules.
+
+### Helper-Over-Primitive Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.
+
+### CLI Reference Drift Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.
+
+### Per-Subcommand Help Snapshots
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.
+
+### Claude Code Hook Dispatch
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- .claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.

--- a/instructions.typescript-js.github-actions.md
+++ b/instructions.typescript-js.github-actions.md
@@ -7,7 +7,24 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ## Core Requirements
 
+### Git Attributes (Line Endings)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce line endings at the Git layer using .gitattributes. Mark text files with appropriate EOL handling (eol=lf for shell scripts, eol=auto for most files) and binary files as binary to prevent corruption. This prevents 'works locally, fails in CI' issues caused by CRLF/LF mismatches.
+- Ensure .gitattributes exists in the repository.
+- Consider adding .editorconfig if applicable.
+
+### CRLF Detection in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Fail CI early for Linux-executed files containing CRLF line endings. Shell scripts, Python files, and other interpreted files fail silently or with cryptic errors when they contain \r characters. Detect this before running deeper CI steps.
+- Check for CRLF in .sh, .js, .ts, .json files early in CI. Use 'file' command or grep for \r to detect issues before they cause cryptic failures.
+
 ### Git and Docker Ignore Files
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain proper .gitignore and .dockerignore files to prevent committing secrets, build artifacts, or unnecessary files.
 - Ensure .gitignore exists in the repository.
@@ -15,13 +32,16 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Linting
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run static code linting to enforce consistency and catch common issues early.
-- Ensure eslint.config.js exists in the repository.
-- Consider adding .eslintrc.js, .eslintrc.cjs, .eslintrc.json and others if applicable.
+- Consider adding .prettierrc, prettier.config.js, prettier.config.cjs and others if applicable.
 - Define a `lint` script or equivalent command.
 - Treat new lint errors as CI failures; keep existing issues as warnings until addressed.
 
 ### Unit Test Runner
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Provide a deterministic unit test framework with a single command to run all tests.
 - Consider adding jest.config.js, jest.config.ts, vitest.config.js and others if applicable.
@@ -30,6 +50,8 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Containerization (Docker / Docker Compose)
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Provide a Dockerfile and, if applicable, a docker-compose file for local dev and CI parity.
 - Ensure Dockerfile exists in the repository.
 - Consider adding docker-compose.yml if applicable.
@@ -37,52 +59,140 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Semantic Versioning
 
-- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use MAJOR.MINOR.PATCH versioning with clear rules and automated changelog generation based on commit history. Maintain a single canonical version source (for example, package.json or VERSION) that all release artifacts use.
+- Ensure package.json exists in the repository.
+- Consider adding VERSION, CHANGELOG.md if applicable.
+- Define a `release` script or equivalent command.
+
+### Version Guard (Automated Releases)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- If semantic-release or automated versioning is enabled, block manual edits to canonical version fields in pull requests. Enforce a CI guard (and optional pre-push hook) that fails when version lines change outside the release workflow.
+- Ensure package.json exists in the repository.
+- Consider adding VERSION if applicable.
+
+### Release Artifact Formatter Exclusion
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Exclude auto-generated release artifacts (CHANGELOG.md, package-lock.json, etc.) from code formatters to prevent CI failures. Release automation tools generate files that may not conform to your formatter's style, causing format checks to fail on subsequent CI runs.
+- Ensure .prettierignore exists in the repository.
+
+### Unified Release Workflow
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use a single CI release pipeline that publishes all artifacts (GitHub releases, packages, containers) from the same canonical version source.
+- Consider adding CHANGELOG.md, VERSION if applicable.
+- Define a `release` script or equivalent command.
+
+### Release Hook Bypass
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Release automation must bypass local developer hooks (HUSKY=0, --no-verify) and rely solely on CI gates for validation. This ensures idempotent, reproducible releases that don't fail due to hook environment differences.
 
 ### Commit Linting
 
-- Enforce structured commit messages such as Conventional Commits.
-- Enforce commit message format via commit-msg hooks (e.g., Husky) before CI.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce structured commit messages such as Conventional Commits via commit-msg hooks and CI. This is required for deterministic versioning and changelog generation.
+- Define a `commitlint` script or equivalent command.
+- Enforce Conventional Commits via commit-msg hooks (e.g., Husky) and a CI job so versioning/changelog automation is deterministic.
 
 ### Unit Test Reporter / Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Generate readable unit test and coverage reports and enforce a minimum coverage threshold (around 80%) for new or changed code.
 - Collect coverage in lcov or similar format; use diff coverage so legacy gaps are visible but non-blocking.
 
 ### CI Quality Gates
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Single CI pipeline that runs linting, formatting, type checking, tests, coverage, build, and containerization.
 - Expose a single npm script (e.g., `npm run ci`) that mirrors the CI pipeline so contributors can reproduce failures locally.
 
 ### Code Formatter
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Automatic code formatting to maintain a consistent style across all contributors.
 - Run Prettier in check mode in CI; auto-fix locally via pre-commit hooks or editor integration.
 
 ### Pre-Commit Hooks
 
-- Use git hooks to run linting, formatting, tests, and commit linting before changes are committed.
-- Run ESLint and Prettier on staged files and enforce commit message format via commit-msg hooks.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use git hooks to run linting, formatting, and commit linting before changes are committed. Hooks should CHECK by default (not auto-fix), be fast, and scope to changed files only. Use a single entry hook mechanism (e.g., Husky as entry point calling pre-commit or lint-staged).
+
+### Hook/CI Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Local hooks and CI must invoke identical verification commands to prevent 'works locally, fails in CI' issues. Use a single canonical verify entrypoint (e.g., npm run verify) that both hooks and CI call.
+- Define a `verify` script or equivalent command.
+
+### Pre-commit Secret Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scan staged diffs for credentials, API keys, and secrets before they reach the remote repository. Catch secrets at commit time rather than after they're pushed.
+- Add gitleaks or detect-secrets to pre-commit hooks. Scan only staged changes for speed. Configure allowlists for false positives in .gitleaks.toml.
 
 ### Type Checking
 
-- Use static type checking to catch errors before runtime and enforce strictness on new code.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use static type checking to catch errors before runtime and enforce strictness on new code. For JS/TS stacks, require a TypeScript-first policy with strict mode and a CI typecheck step; allow JSDoc/checkJs migration for legacy JS.
 - Ensure tsconfig.json exists in the repository.
 - Define a `typecheck` script or equivalent command.
-- Enable strict mode ('strict': true) and treat type-check failures as CI failures for new code; gradually expand strictness into legacy modules.
 
 ### Dependency Management & Vulnerability Scanning
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Lock dependencies and scan regularly for known vulnerabilities; fail CI on newly introduced high-severity issues.
 - Consider adding package-lock.json, pnpm-lock.yaml, yarn.lock if applicable.
 - Require a lockfile for reproducible installs and pin Node.js/tooling versions; block merges on new high-severity vulnerabilities.
 
+### Deterministic & Hermetic Builds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ensure builds are reproducible by pinning dependencies, base images, and tool/runtime versions. Avoid network/time variance and fail when lockfiles drift.
+- Consider adding .nvmrc, .tool-versions if applicable.
+
+### Provenance & Security Metadata
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Produce SBOMs or provenance metadata, enable secret/code scanning, and sign tags or commits for critical repos.
+- Consider adding SECURITY.md, .github/workflows/codeql.yml if applicable.
+- Generate SBOM/provenance for npm and container artifacts, enable secret scanning, and sign tags/commits for protected branches.
+
+### CI Templates & Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Adopt standard CI templates and config samples to scale across repositories, minimizing bespoke pipeline logic.
+- Define a `ci` script or equivalent command.
+- Use shared CI templates for lint/test/build/release stages and keep repo-specific overrides minimal.
+
 ### Runtime Version Specification
 
-- Specify required runtime/engine versions in package manifests to ensure environment stability and prevent version-related issues across development teams.
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Specify required runtime/engine versions in package manifests appropriate for your application. Use minimum version constraints (>=) rather than strict ranges to avoid blocking consumers from upgrading.
 - Ensure package.json exists in the repository.
 
 ### Documentation Standards
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Maintain a comprehensive README and, where applicable, auto-generated API docs to support onboarding and maintainability.
 - Ensure README.md exists in the repository.
@@ -91,36 +201,203 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Repository Governance
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Include standard governance files (LICENSE, CODE_OF_CONDUCT.md, CONTRIBUTING.md), branch protection rules, and review standards to define legal, ethical, and workflow expectations.
 - Ensure LICENSE exists in the repository.
 - Consider adding CODE_OF_CONDUCT.md, CONTRIBUTING.md if applicable.
 - Use an SPDX license identifier in package.json and describe review expectations, tests, and docs requirements in CONTRIBUTING.md.
 
+### Canonical Verify Entrypoint
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Provide one canonical 'verify' command per repository/stack that all stages call with appropriate flags. This prevents duplication, drift, and ensures consistency between local development and CI.
+- Define a `verify` script or equivalent command.
+
+### Config File Authority Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Each configuration rule must live in exactly one authoritative config file. Avoid duplication across .editorconfig, linter configs, and CI definitions. Document which file is authoritative for each concern.
+
+### Explicit Skip Paths
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Encode path exclusions and skip rules deterministically in config files, not through ad-hoc human judgment. Make it clear which paths are excluded from checks and why.
+
+### Hook Exit-Code Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
+
 ## Recommended Practices
 
+### Dependency Update Automation
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Automate dependency updates using Renovate or Dependabot to keep dependencies current and reduce security exposure window.
+
+### Dependency Architecture Rules
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce module boundaries and import constraints to prevent architectural drift and unwanted coupling.
+- Define forbidden imports, layer rules, and circular dependency bans. Run in CI as blocking check.
+
 ### Integration Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Test how components interact with each other and external systems, running after unit tests with more relaxed coverage thresholds.
 - Use Supertest for HTTP APIs and Playwright or similar tools for end-to-end flows; keep integration suites slower but reliable.
 
 ### Performance Baselines
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Establish performance baselines and monitor for regressions using lightweight benchmarks or audits in CI.
 - Run Lighthouse CI for web apps and basic Node benchmarks on critical endpoints; schedule runs or limit to key branches to keep CI fast.
 
 ### Complexity Analysis
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Measure cyclomatic complexity or similar metrics to keep code maintainable, starting as a warning-only check.
 - Warn on overly complex functions and methods; fail CI only when new or modified code exceeds thresholds.
 
 ### Accessibility Auditing
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Run accessibility checks on web-facing components to detect critical issues and improve inclusive UX.
 - Run accessibility checks against key pages or components in CI; fail on critical violations while treating minor issues as warnings initially.
+
+### AI Drift Detection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run nightly or scheduled checks comparing AI-generated outputs against pinned baselines to detect model drift, prompt drift, or code changes affecting AI behavior. Attribute regressions to code changes vs model updates vs prompt changes.
+
+### AI Output Schema Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate all AI-generated outputs against strict JSON schemas or type definitions at system boundaries. Reject invalid outputs early rather than letting malformed data propagate through the system.
+
+### AI Golden Contract Tests
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Validate AI tool-generated patches, configs, and code against exact expected formats. Test that AI outputs respect forbidden paths, file patterns, and format constraints through golden contract tests.
+
+### AI Adversarial & Safety Testing
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test AI integrations for prompt injection resistance, input sanitization, output filtering, and data exfiltration prevention. Include adversarial test cases that attempt to manipulate AI behavior.
+
+### AI Provenance & Audit Logging
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Log AI provider, model version, prompt template version, parameters, and tool versions for all AI operations. Enable attribution of outputs to specific model+prompt combinations for debugging and compliance.
+
+### Autonomous Agent Invariants
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Maintain INVARIANTS.md defining repository-wide rules that must always hold true, with machine-readable verification commands for autonomous agents.
+- Ensure INVARIANTS.md exists in the repository.
+
+### Local/CI Parity Invariants Document
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- A row-per-gate matrix — typically LOCAL_CI_PARITY_INVARIANTS.md — that maps every local gate to its CI equivalent with a status column (Match / Weaker / Partial). Makes parity gaps concretely auditable and prevents 'works locally' drift.
+
+### Parity Doc Coverage Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test that AST-walks the local preflight runner, collects every gate's canonical identifier, and asserts each appears in the parity doc. Lock scope to identifier presence only — never prose, row counts, or link shapes — or the test devolves into churn-bait. Must include adversarial negative tests proving it catches fabricated and removed gates.
+
+### Tiered Hook Model
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook checks organize into three tiers: pre-commit (staged-only, fast), pre-push (CI-identical preflight superset), CI (remote-only jobs). Makes the local/CI boundary explicit and keeps fast-feedback checks from drifting toward either extreme.
+
+### Hook Dispatcher Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Single entrypoint script that husky hooks delegate to. Routes pre-commit / pre-push / commit-msg based on argv, centralizes exit-code handling, tool detection, and network-degraded behavior so individual hook files stay thin and consistent.
+
+### Pre-Push Preflight Script
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Dedicated script that runs the CI-identical superset of gates. Pre-push hook invokes it; CI can also invoke it. Keeps local and CI verification paths mechanically equivalent rather than merely 'similar.'
+
+### Fail-Fast Hook Setup Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Hook scripts verify prerequisites upfront — .husky/ present, required tools on PATH, harness wired — and fail with a setup-specific exit code when any are missing. Prevents silent hook bypass after bad installs, branch switches, or dependency drift.
+
+### Schema/Migration Parity Test
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
+
+### Migration DDL Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
+
+### Required-Tables Runtime Check
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
+
+### Schema Version Seed Monotonic
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
+
+### Per-Migration Test Coverage
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 
 ## Optional Enhancements
 
 ### Observability (Logging & Error Handling)
 
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
 - Standardize error handling and structured logging to make debugging and production monitoring easier.
 - Adopt structured JSON logging with correlation IDs and send logs to a centralized sink in production.
+
+### Agent Phase Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Define phase transition requirements in phase-gates.md for autonomous agent workflows with clear pre-conditions and approval gates.
+- Consider adding phase-gates.md if applicable.
+
+### Agent Victory Gates
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
+- Consider adding victory-gates.md if applicable.

--- a/instructions.typescript-js.github-actions.md
+++ b/instructions.typescript-js.github-actions.md
@@ -233,6 +233,54 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Three-value exit-code contract shared across all hook scripts and CI preflight runners: 1 = quality regression (fatal), 2 = missing tool (fatal, setup issue), 3 = network or infra degraded (skippable with --allow-local-degraded). Inconsistent exit semantics across hooks mask real failures and undermine local/CI parity.
 
+### Package Manager Exclusivity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Enforce a single package manager per repo via a preinstall script that exits non-zero if the wrong one is invoked. Combined with engine-strict, prevents lockfile drift and npm/pnpm mixed installs that break reproducibility.
+
+### Lockfile Discipline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate fails on the presence of any unauthorized lockfile — e.g., a package-lock.json in a pnpm repo, or a yarn.lock in an npm repo. Companion to package-manager exclusivity; catches wrong-tool installs that slip past the preinstall guard.
+
+### packageManager Field
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- package.json declares a pinned `packageManager` field (e.g., "pnpm@9.15.0") that Corepack and CI can use to auto-select the correct tool + version. Keeps the package-manager exclusivity guard and engine pins aligned with one authoritative source.
+
+### EditorConfig
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ship an .editorconfig at the repo root pinning UTF-8 charset, LF line endings, trimmed trailing whitespace, and inserted final newline. Overrides by extension for language-specific indent widths and any Windows-only exceptions (e.g., CRLF for .bat). Eliminates an entire class of cross-platform whitespace drift before linters run.
+
+### engine-strict Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Set engine-strict=true in .npmrc (or equivalent) so the engines field in package.json becomes a hard install-time constraint, not advisory. Prevents 'works on my machine' drift from mismatched Node or package-manager versions.
+
+### Zero-Warnings Lint Discipline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run the linter with --max-warnings=0 (or equivalent) so any warning becomes a failure. Complements the generic linting requirement by forcing warnings to be resolved at authorship time rather than accumulating as background noise.
+
+### Full-History Secret Scan in CI
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Run a secret scanner (e.g., gitleaks) in CI against the full git history on every PR — fetch-depth: 0. Complements pre-commit secret scanning by catching anything that slipped in via force-push, rebase, or a developer without hooks installed.
+
+### semantic-release Integration
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Use semantic-release (or equivalent) on the main branch only, with a git plugin that commits version and changelog files and a [skip ci] convention on the release commit. Complements the unified release workflow with a specific, deterministic tool stack that enforces conventional-commit-driven versioning.
+
 ## Recommended Practices
 
 ### Dependency Update Automation
@@ -378,6 +426,72 @@ This document provides high-level guidance for an autonomous coding agent to bri
 > **Maturity:** `documented` — described here; no ready-to-copy template yet
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
+
+### Justified Lint Ignores
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Every linter ignore or suppression comment includes an inline justification explaining why the rule doesn't apply in that specific case. Zero silent suppressions; reviewers can audit the trade-off directly at the call site.
+
+### Coverage Ratchet (Raise-Only)
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Coverage threshold computed as floor(actual - 2.0); CI fails on regression below the ratchet but allows raises. Makes coverage monotonically improve over time without requiring human-maintained magic numbers.
+
+### Tiered Coverage Thresholds
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Global coverage baseline supplemented by per-file Tier 2 thresholds for critical paths — schemas, parsers, auth boundaries, security-sensitive surfaces. Keeps high-risk code at a higher bar without demanding the same bar of every file.
+
+### Coverage Delta Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate fails when the PR's coverage drops by more than a small delta (e.g., 2%) vs. main, even if the absolute number still sits above the ratchet. Catches silent coverage erosion that ratchets alone miss.
+
+### Test Floor Contract
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit a machine-readable contract file (e.g., .test-floor-contract.json) that pins the minimum collected test count. CI reads this authoritatively — no hardcoded integers in workflow files. Catches silent test removal that coverage alone wouldn't flag.
+
+### Ratchet Bump Equality Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Per-commit gate asserting collected test count equals the floor exactly after any floor bump. Walks the first-parent commit range in subprocess-isolated pytest (or equivalent) so the check matches CI's collection exactly. Prevents 'bumped the floor but tests changed' drift.
+
+### Threshold Change Marker Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks coverage-threshold changes unless the commit subject contains a [threshold-update] marker. Keeps accidental threshold drift from slipping through reviews while still allowing intentional adjustments with a clear audit trail.
+
+### Commit-Subject Marker Bypass Convention
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Subject-line-only markers (e.g., [threshold-update], [ratchet-realignment], [version-override-acknowledged]) document cases where a strict gate is intentionally bypassed. Scanned via git log --oneline with shallow-clone determinism checks. Only meaningful once ratchet/threshold/version guards exist; adopt alongside them.
+
+### Package-Manager Command Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate scans workflows, scripts, and configs for forbidden package-manager commands — e.g., 'npm install' or 'npm ci' in a pnpm-exclusive repo. Catches drift that the preinstall guard alone won't: workflow-file edits that bypass installs entirely.
+
+### Rule-Disable Proof Artifact
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a committed proof artifact (e.g., .rule-disable-audit-<rule>.json) listing every affected call-site and the compensating control. Verified by an exact-match check on every run so new call-sites can't silently inherit the disable.
+
+### Suppression Audit with Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Scope-based suppression baseline (e.g., .suppression-baseline.json) with zero-tolerance scope policy: any new suppression outside the baseline blocks the commit. Baseline is regenerated and staleness-checked on every run so it can't silently grow stale.
 
 ## Optional Enhancements
 

--- a/instructions.typescript-js.github-actions.md
+++ b/instructions.typescript-js.github-actions.md
@@ -399,31 +399,31 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 ### Schema/Migration Parity Test
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Static test asserting every table declared in the canonical schema source is either in a 'fundamental' set (present since inception) or created by at least one registered migration. Shifts detection of 'added table to schema, forgot the migration' from production runtime to PR CI.
 
 ### Migration DDL Byte-Parity
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - PRAGMA/DDL byte-equivalence test between (a) the canonical schema source and (b) a DB built by running every registered migration against a blank start. Catches semantic drift between inline schema and incremental migrations.
 
 ### Required-Tables Runtime Check
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - At DB connect time, validate table presence in two phases — 'fundamental' tables before any migrations run, 'required' tables after all migrations apply. Defense-in-depth alongside the parity test; catches the same defect class at runtime if it escapes PR gating.
 
 ### Schema Version Seed Monotonic
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - CI gate asserting the schema_version seed in the canonical schema source equals max(target_version) across all registered migrations. Catches 'added migration, forgot to bump seed' — where the DB migrates to v7 but schema source still claims v6.
 
 ### Per-Migration Test Coverage
 
-> **Maturity:** `documented` — described here; no ready-to-copy template yet
+> **Maturity:** `template-available` — template at `templates/patterns/<id>/` — ready to copy-and-adapt
 
 - Every registered migration has at least one test exercising it on a blank DB AND on the prior schema version. Enforced by a coverage check over the migration registry. Blocks untested migrations from shipping.
 

--- a/instructions.typescript-js.github-actions.md
+++ b/instructions.typescript-js.github-actions.md
@@ -515,3 +515,105 @@ This document provides high-level guidance for an autonomous coding agent to bri
 
 - Document milestone completion criteria in victory-gates.md defining 'done' for releases and major deliverables with evidence requirements.
 - Consider adding victory-gates.md if applicable.
+
+### Split TypeScript Configs
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Separate tsconfig files for typecheck (strict, bundler resolution), build (emit, CommonJS or ESM as appropriate), tests, and type-tests. A guard test locks module/moduleResolution per config so tsc cannot silently overwrite an IIFE bundle with a CommonJS one, or vice versa.
+
+### No any / Any Types
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate forbidding 'any' (TypeScript) or 'typing.Any' (Python) in src/, tests/, and scripts/ except for a small allowlist with inline justifications. Prevents silently-typed escape hatches from accumulating undetected over time.
+
+### Patch Coverage Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Gate on patch coverage (e.g., via Codecov project status or equivalent) asserting newly-added lines meet a minimum bar, separate from the global coverage ratchet. Keeps new code honest even when overall coverage sits safely above threshold.
+
+### Zero-Skips Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Test collection runs with zero-tolerance for skipped tests — e.g., pytest --max-skips=0. Skips become failures; prefer collection-time exclusion patterns (platform filters, custom markers) over per-test skip decorators so skips remain visible.
+
+### Platform-Conditional Test Collection Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Shared glob constants imported by both the test runner's conftest (or equivalent) and the ratchet-bump gate so platform-conditional collection stays identical across both sites. AST-level parity test asserts both sites import the same canonical constant name rather than drifting into divergent literal lists.
+
+### Canonical Runtime Baseline
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Pin one canonical OS + runtime version as the baseline for coverage, test counts, and any threshold comparison — e.g., ubuntu-latest + Python 3.12. Other matrix legs run tests but do not gate thresholds, so argparse rendering or stdlib diffs cannot destabilize CI.
+
+### Subprocess-Isolated Test Collection
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Ratchet-bump and count-check scripts invoke the test runner in a clean subprocess with plugin autoload disabled and addopts cleared, writing the count to a tempfile instead of parsing stdout. Guarantees local ratchet measurement matches CI byte-for-byte regardless of dev-machine plugin state.
+
+### LCOV Partial-Branch Ratchet
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- LCOV partial-branches baseline with a locked-zero files list. CI fails if a file on the locked-zero list develops any partial branches. Catches a class of untested conditional branches that line and statement coverage alone do not detect.
+
+### Shallow-Clone Marker-Scan Determinism
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- When scanning commit history for markers (bypass, version-override, etc.), fetch without --depth=N. Cross-check the count from git log {base}..HEAD against git rev-list --count and fail the gate if they disagree. Prevents shallow-clone-related silent marker misses on CI runners.
+
+### Generated-Artifact Byte-Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI verifies that any checked-in generated artifact — compiled UI bundle, golden docs, mirrored schema, etc. — is byte-identical to what a fresh regeneration would produce. Applies only to repos that check in generated files. Catches manual edits that would be silently overwritten on the next regeneration.
+
+### Breaking-Change Marker Gate
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks major-version bumps of contract files (schemas, task definitions, API specs) unless the commit message contains a project-defined marker such as 'BREAKING <CONTRACT>:'. Applies only to repos that ship versioned contracts. Forces breaking changes through an explicit review checkpoint.
+
+### Cross-Platform Test-Count Parity
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Compare test counts between OS matrix legs (ubuntu vs windows vs macos, etc.) and fail the gate on unexpected disagreement. Catches platform-filter bugs where a test silently collects on only one OS due to an accidental glob or marker.
+
+### Rule-Disable Compensating Guardrail
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- For every globally disabled lint rule, ship a custom validator that enforces the compensating control — e.g., if S603 (subprocess) is disabled, a guardrail verifies every subprocess call is either a string literal or appears in an allowlist. Uses tokenizer-based parsing (not regex) to avoid false positives inside string literals. Runs alongside the proof artifact as defense-in-depth.
+
+### Helper-Over-Primitive Enforcement
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- CI gate blocks direct use of primitives where a safer helper exists — for example, pagination tokens must route through a helper function rather than being string-concatenated, or crypto primitives must go through a project wrapper. The helper's existence alone is not enough; the underlying primitive must be blocked.
+
+### CLI Reference Drift Guard
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Auto-generate the CLI reference doc (e.g., docs/reference/cli-reference.md) and commit a golden SHA of the expected output. CI regenerates and compares. Use a canonical runtime only (argparse and equivalent CLI formatters render differently across language/runtime versions); --check mode returns [SKIP] on non-canonical runtimes; fail-close in write mode.
+
+### Per-Subcommand Help Snapshots
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- Commit per-subcommand help-output snapshots so any accidental change to --help text is visible in PR diff. Paired with the CLI reference drift guard to give full CLI documentation coverage — drift guard catches added/removed commands; snapshots catch wording changes on existing commands.
+
+### Claude Code Hook Dispatch
+
+> **Maturity:** `documented` — described here; no ready-to-copy template yet
+
+- .claude/settings.json wires pre/post/session hooks to a single orchestrator binary or stack-native dispatcher. Centralizes agent-invoked checks so they don't drift from human-invoked pre-commit / pre-push hooks or CI. Keeps the agent, the developer, and CI on the same verification path.

--- a/scripts/generate-instructions.ts
+++ b/scripts/generate-instructions.ts
@@ -18,12 +18,36 @@ interface StackHints {
   requiredScripts?: string[];
 }
 
+type Maturity = "documented" | "template-planned" | "template-available";
+
 interface ChecklistItem {
   id: string;
   label: string;
   description: string;
+  maturity: Maturity;
+  conditions?: string[];
   ciHints?: Record<string, { job?: string; stage?: string }>;
   stack?: StackHints;
+}
+
+/**
+ * Consumer-facing explanation for each maturity value.
+ * Kept terse so the rendered line stays scannable next to dozens of items.
+ */
+const MATURITY_EXPLANATIONS: Record<Maturity, string> = {
+  documented: "described here; no ready-to-copy template yet",
+  "template-planned": "template scheduled; not yet ready to copy",
+  "template-available":
+    "template at `templates/patterns/<id>/` — ready to copy-and-adapt",
+};
+
+/**
+ * Render the maturity signal as a one-line blockquote to surface inline
+ * beneath each item heading. Required on every item (schema-enforced).
+ */
+function formatMaturity(item: ChecklistItem): string {
+  const explanation = MATURITY_EXPLANATIONS[item.maturity];
+  return `> **Maturity:** \`${item.maturity}\` — ${explanation}`;
 }
 
 interface StackChecklistJson {
@@ -85,6 +109,8 @@ function generateSection(title: string, items: ChecklistItem[]): string {
 
   for (const item of items) {
     lines.push(`### ${item.label}`);
+    lines.push("");
+    lines.push(formatMaturity(item));
     lines.push("");
 
     const bullets = generateBullets(item);

--- a/scripts/generate-standards.ts
+++ b/scripts/generate-standards.ts
@@ -70,10 +70,14 @@ interface StackHints {
   bazelHints?: BazelHints;
 }
 
+type Maturity = "documented" | "template-planned" | "template-available";
+
 interface ChecklistItemMaster {
   id: string;
   label: string;
   description: string;
+  maturity: Maturity;
+  conditions?: string[];
   appliesTo: {
     stacks: StackId[];
     ciSystems?: CiSystem[];
@@ -121,6 +125,8 @@ interface StackItem {
   id: string;
   label: string;
   description: string;
+  maturity: Maturity;
+  conditions?: string[];
   ciHints?: CiHints;
   // For the filtered file, this is the single stack’s hints including verification
   stack?: StackHints;
@@ -160,7 +166,12 @@ function filterSectionForStackAndCi(
         id: item.id,
         label: item.label,
         description: item.description,
+        maturity: item.maturity,
       };
+
+      if (item.conditions?.length) {
+        result.conditions = item.conditions;
+      }
 
       if (item.ciHints) {
         if (ciSystem) {

--- a/scripts/verify-pattern-footers.test.ts
+++ b/scripts/verify-pattern-footers.test.ts
@@ -1,0 +1,240 @@
+// scripts/verify-pattern-footers.test.ts
+
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  checkPatternReadme,
+  parseKnownMetaPrincipleIds,
+  verifyAllPatternReadmes,
+} from "./verify-pattern-footers.js";
+
+const EXPECTED_MP_IDS = new Set([
+  "mp-adversarial-proof-required",
+  "mp-churn-bait-discipline",
+  "mp-committed-proof-artifacts",
+  "mp-defense-in-depth",
+  "mp-point-in-time-structural-claims",
+  "mp-authoritative-contract-file",
+  "mp-enforce-helpers-over-primitives",
+  "mp-allowlist-over-blocklist",
+]);
+
+const REPO_ROOT = process.cwd();
+const META_PATH = path.join(
+  REPO_ROOT,
+  "docs",
+  "patterns",
+  "meta-principles.md",
+);
+
+function validFooter(refs: string[]): string {
+  const cites = refs.map((r) => `\`${r}\``).join(", ");
+  return [
+    "# p-fixture",
+    "",
+    "## Design principles this template obeys",
+    "",
+    `This pattern follows: ${cites} — see [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.`,
+    "",
+  ].join("\n");
+}
+
+function stageFixture(readmes: Record<string, string | null>): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pattern-footers-"));
+  fs.mkdirSync(path.join(tmp, "docs", "patterns"), { recursive: true });
+  fs.copyFileSync(
+    META_PATH,
+    path.join(tmp, "docs", "patterns", "meta-principles.md"),
+  );
+  for (const [id, content] of Object.entries(readmes)) {
+    const dir = path.join(tmp, "templates", "patterns", id);
+    fs.mkdirSync(dir, { recursive: true });
+    if (content !== null) {
+      fs.writeFileSync(path.join(dir, "README.md"), content);
+    }
+  }
+  return tmp;
+}
+
+describe("parseKnownMetaPrincipleIds — authoritative set from meta-principles.md", () => {
+  it("extracts the 8 mp-* IDs declared in the doc", () => {
+    const content = fs.readFileSync(META_PATH, "utf8");
+    const ids = parseKnownMetaPrincipleIds(content);
+    expect(ids).toEqual(EXPECTED_MP_IDS);
+  });
+
+  it("returns empty set for a doc with no mp-* headings", () => {
+    const ids = parseKnownMetaPrincipleIds(
+      "# Nothing\n\nSome prose without any headings.\n",
+    );
+    expect(ids.size).toBe(0);
+  });
+});
+
+describe("checkPatternReadme — positive cases", () => {
+  it("accepts a footer citing a single known principle", () => {
+    const result = checkPatternReadme(
+      validFooter(["mp-adversarial-proof-required"]),
+      EXPECTED_MP_IDS,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.references).toEqual(["mp-adversarial-proof-required"]);
+  });
+
+  it("accepts a footer citing multiple known principles", () => {
+    const result = checkPatternReadme(
+      validFooter([
+        "mp-adversarial-proof-required",
+        "mp-defense-in-depth",
+        "mp-committed-proof-artifacts",
+      ]),
+      EXPECTED_MP_IDS,
+    );
+    expect(result.valid).toBe(true);
+    expect(result.references).toHaveLength(3);
+  });
+
+  it("accepts churn-bait cite when the README carries a Scope discipline anchor", () => {
+    const readme = [
+      "# p-example",
+      "",
+      "## Scope discipline",
+      "",
+      "This test locks canonical identifier presence only.",
+      "",
+      "## Design principles this template obeys",
+      "",
+      "Follows `mp-churn-bait-discipline`, `mp-adversarial-proof-required`.",
+    ].join("\n");
+    const result = checkPatternReadme(readme, EXPECTED_MP_IDS);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("checkPatternReadme — adversarial: proves the gate fires", () => {
+  it("rejects README with no footer section at all", () => {
+    const result = checkPatternReadme(
+      "# p-example\n\nBody content, nothing else.\n",
+      EXPECTED_MP_IDS,
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/missing.*section/);
+  });
+
+  it("rejects footer present but citing zero mp-* principles", () => {
+    const readme = [
+      "# p-example",
+      "",
+      "## Design principles this template obeys",
+      "",
+      "This pattern follows best practices — see the meta-principles doc.",
+    ].join("\n");
+    const result = checkPatternReadme(readme, EXPECTED_MP_IDS);
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toMatch(/cites no mp-\* principles/);
+  });
+
+  it("rejects a typo'd mp-* ID (mp-adverserial-proof)", () => {
+    const readme = validFooter(["mp-adverserial-proof"]);
+    const result = checkPatternReadme(readme, EXPECTED_MP_IDS);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) =>
+        e.includes(`unknown meta-principle "mp-adverserial-proof"`),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects mixed valid + typo'd IDs (partial invalidation still fails)", () => {
+    const readme = validFooter([
+      "mp-adversarial-proof-required",
+      "mp-typoed-id",
+    ]);
+    const result = checkPatternReadme(readme, EXPECTED_MP_IDS);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("mp-typoed-id"))).toBe(true);
+  });
+
+  it("rejects churn-bait cite without a Scope discipline anchor", () => {
+    const readme = validFooter(["mp-churn-bait-discipline"]);
+    const result = checkPatternReadme(readme, EXPECTED_MP_IDS);
+    expect(result.valid).toBe(false);
+    expect(
+      result.errors.some((e) =>
+        e.includes("mp-churn-bait-discipline but README lacks"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("verifyAllPatternReadmes — integration over a staged tree", () => {
+  it("returns valid=true with checked=0 when templates/patterns/ is absent", () => {
+    const tmp = stageFixture({});
+    try {
+      const result = verifyAllPatternReadmes(tmp);
+      expect(result.valid).toBe(true);
+      expect(result.checked).toBe(0);
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it("reports missing README.md for an orphan pattern directory", () => {
+    const tmp = stageFixture({ "p-orphan": null });
+    try {
+      const result = verifyAllPatternReadmes(tmp);
+      expect(result.valid).toBe(false);
+      expect(result.perReadme[0]?.errors[0]).toMatch(/README\.md missing/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it("surfaces per-README errors for a template with a typo'd mp-* ID", () => {
+    const tmp = stageFixture({
+      "p-typo": validFooter(["mp-adverserial-proof"]),
+    });
+    try {
+      const result = verifyAllPatternReadmes(tmp);
+      expect(result.valid).toBe(false);
+      expect(
+        result.perReadme[0]?.errors.some((e) =>
+          e.includes("mp-adverserial-proof"),
+        ),
+      ).toBe(true);
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+
+  it("accepts a well-formed pattern directory", () => {
+    const tmp = stageFixture({
+      "p-good": validFooter([
+        "mp-adversarial-proof-required",
+        "mp-defense-in-depth",
+      ]),
+    });
+    try {
+      const result = verifyAllPatternReadmes(tmp);
+      expect(result.valid).toBe(true);
+      expect(result.checked).toBe(1);
+    } finally {
+      fs.rmSync(tmp, { recursive: true });
+    }
+  });
+});
+
+describe("verifyAllPatternReadmes — always-on check against real repo", () => {
+  it("passes for the actual repo (vacuous if templates/patterns/ is empty)", () => {
+    const result = verifyAllPatternReadmes(REPO_ROOT);
+    expect(
+      result.valid,
+      result.perReadme
+        .map((e) => `${e.path}: ${e.errors.join("; ")}`)
+        .join("\n"),
+    ).toBe(true);
+  });
+});

--- a/scripts/verify-pattern-footers.ts
+++ b/scripts/verify-pattern-footers.ts
@@ -1,0 +1,173 @@
+// scripts/verify-pattern-footers.ts
+
+/**
+ * Validates the meta-principles footer on every pattern template README.
+ *
+ * Every `templates/patterns/<id>/README.md` MUST end with a section of the form:
+ *
+ *   ## Design principles this template obeys
+ *
+ *   This pattern follows: `mp-...`, `mp-...` — see
+ *   [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.
+ *
+ * The gate enforces three properties:
+ *   1. The footer section is present.
+ *   2. At least one `mp-*` principle is cited (no empty footers).
+ *   3. Every cited `mp-*` ID exists in the authoritative set parsed from
+ *      `docs/patterns/meta-principles.md` (catches typos).
+ *
+ * An additional structural check: any template citing `mp-churn-bait-discipline`
+ * must carry a "Scope discipline" anchor somewhere in its README, since the
+ * principle's whole point is preserving a narrow lock surface against
+ * future-expander pressure.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export interface FooterCheckResult {
+  valid: boolean;
+  errors: string[];
+  references: string[];
+}
+
+export interface VerifyAllResult {
+  valid: boolean;
+  checked: number;
+  perReadme: Array<{ path: string; errors: string[] }>;
+}
+
+const FOOTER_HEADING = "## Design principles this template obeys";
+const MP_REFERENCE = /`(mp-[a-z0-9-]+)`/g;
+const MP_HEADING = /^##\s+`(mp-[a-z0-9-]+)`/gm;
+const SCOPE_DISCIPLINE_ANCHOR = /scope[\s-]discipline/i;
+
+/**
+ * Parse the canonical set of mp-* IDs from meta-principles.md itself.
+ *
+ * The doc is the authority for the set (mp-authoritative-contract-file):
+ * adding a new principle means adding an `## \`mp-xyz\`` heading there, and
+ * this gate picks it up automatically.
+ */
+export function parseKnownMetaPrincipleIds(docContent: string): Set<string> {
+  const ids = new Set<string>();
+  for (const match of docContent.matchAll(MP_HEADING)) {
+    if (match[1]) ids.add(match[1]);
+  }
+  return ids;
+}
+
+/**
+ * Check a single README against the footer contract.
+ */
+export function checkPatternReadme(
+  readmeContent: string,
+  knownMpIds: Set<string>,
+): FooterCheckResult {
+  const errors: string[] = [];
+  const references: string[] = [];
+
+  const footerIdx = readmeContent.indexOf(FOOTER_HEADING);
+  if (footerIdx === -1) {
+    errors.push(`missing "${FOOTER_HEADING}" section`);
+    return { valid: false, errors, references };
+  }
+
+  const footerSection = readmeContent.slice(footerIdx);
+  for (const match of footerSection.matchAll(MP_REFERENCE)) {
+    if (match[1]) references.push(match[1]);
+  }
+
+  if (references.length === 0) {
+    errors.push("footer present but cites no mp-* principles");
+  }
+
+  for (const ref of references) {
+    if (!knownMpIds.has(ref)) {
+      errors.push(
+        `unknown meta-principle "${ref}" — known: ${[...knownMpIds].sort().join(", ")}`,
+      );
+    }
+  }
+
+  if (
+    references.includes("mp-churn-bait-discipline") &&
+    !SCOPE_DISCIPLINE_ANCHOR.test(readmeContent)
+  ) {
+    errors.push(
+      'cites mp-churn-bait-discipline but README lacks a "Scope discipline" anchor',
+    );
+  }
+
+  return { valid: errors.length === 0, errors, references };
+}
+
+/**
+ * Walk `templates/patterns/<id>/README.md` and apply checkPatternReadme to each.
+ *
+ * Vacuous pass when `templates/patterns/` does not yet exist — the directory is
+ * created alongside the first template.
+ */
+export function verifyAllPatternReadmes(repoRoot: string): VerifyAllResult {
+  const metaPath = path.join(
+    repoRoot,
+    "docs",
+    "patterns",
+    "meta-principles.md",
+  );
+  const metaContent = fs.readFileSync(metaPath, "utf8");
+  const knownMpIds = parseKnownMetaPrincipleIds(metaContent);
+
+  const patternsDir = path.join(repoRoot, "templates", "patterns");
+  const perReadme: Array<{ path: string; errors: string[] }> = [];
+
+  if (!fs.existsSync(patternsDir)) {
+    return { valid: true, checked: 0, perReadme };
+  }
+
+  const entries = fs
+    .readdirSync(patternsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory());
+
+  for (const entry of entries) {
+    const readmePath = path.join(patternsDir, entry.name, "README.md");
+    if (!fs.existsSync(readmePath)) {
+      perReadme.push({
+        path: readmePath,
+        errors: [`README.md missing in templates/patterns/${entry.name}/`],
+      });
+      continue;
+    }
+    const readmeContent = fs.readFileSync(readmePath, "utf8");
+    const result = checkPatternReadme(readmeContent, knownMpIds);
+    if (!result.valid) {
+      perReadme.push({ path: readmePath, errors: result.errors });
+    }
+  }
+
+  return {
+    valid: perReadme.length === 0,
+    checked: entries.length,
+    perReadme,
+  };
+}
+
+if (
+  import.meta.url.startsWith("file:") &&
+  process.argv[1]?.includes("verify-pattern-footers")
+) {
+  const result = verifyAllPatternReadmes(process.cwd());
+  if (!result.valid) {
+    console.error("Pattern footer validation failed:");
+    for (const entry of result.perReadme) {
+      console.error(`  ${entry.path}:`);
+      for (const err of entry.errors) {
+        console.error(`    - ${err}`);
+      }
+    }
+    process.exit(1);
+  }
+  console.log(
+    `✓ Meta-principles footer valid on all ${result.checked} pattern README(s)`,
+  );
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -4,8 +4,28 @@
 import type {
   VerifyResult,
   Finding,
+  Tier,
   RemediationClass,
 } from "../schemas/index.js";
+
+/**
+ * Tier ordering for sorting findings.
+ * Core findings surface first so consumers see must-fix items before nice-to-haves.
+ */
+const TIER_ORDER: Record<Tier, number> = {
+  core: 0,
+  recommended: 1,
+  optional: 2,
+};
+
+/**
+ * Sort findings by tier so Core surfaces first, then Recommended, then Optional.
+ * Applied within each remediation-class group so Core-first ordering is
+ * preserved regardless of which group a consumer looks at.
+ */
+function sortByTier(findings: Finding[]): Finding[] {
+  return [...findings].sort((a, b) => TIER_ORDER[a.tier] - TIER_ORDER[b.tier]);
+}
 
 /**
  * Options for the doctor command.
@@ -148,12 +168,14 @@ export async function doctor(
 ): Promise<DoctorReport> {
   const { findings } = verifyResult;
 
-  // Group findings by remediation class
-  const mechanical = findings.filter(
-    (f) => f.remediation_class === "mechanical",
+  // Group findings by remediation class, with Core tier surfaced first within each group
+  const mechanical = sortByTier(
+    findings.filter((f) => f.remediation_class === "mechanical"),
   );
-  const ai = findings.filter((f) => f.remediation_class === "ai");
-  const human = findings.filter((f) => f.remediation_class === "human");
+  const ai = sortByTier(findings.filter((f) => f.remediation_class === "ai"));
+  const human = sortByTier(
+    findings.filter((f) => f.remediation_class === "human"),
+  );
 
   const groups: RemediationGroup[] = [];
 

--- a/src/commands/verify.ts
+++ b/src/commands/verify.ts
@@ -6,6 +6,7 @@ import type {
   VerifyResult,
   VerifySummary,
   Severity,
+  Tier,
   RemediationClass,
 } from "../schemas/index.js";
 import { loadStandardsConfig } from "../core/config-loader.js";
@@ -67,6 +68,11 @@ export async function verify(
       ai: 0,
       human: 0,
     },
+    by_tier: {
+      core: 0,
+      recommended: 0,
+      optional: 0,
+    },
   };
 
   for (const finding of evaluation.findings) {
@@ -74,6 +80,7 @@ export async function verify(
     summary.by_remediation_class[
       finding.remediation_class as RemediationClass
     ]++;
+    summary.by_tier[finding.tier as Tier]++;
   }
 
   // Determine compliance (no error-severity findings)
@@ -88,6 +95,7 @@ export async function verify(
     standards_version: config.version || STANDARDS_VERSION,
     stack_id: config.stack,
     findings: evaluation.findings,
+    not_applicable: evaluation.not_applicable,
     summary,
     repository_path: repoPath,
     execution_time_ms: Date.now() - startTime,

--- a/src/core/__tests__/conditions.test.ts
+++ b/src/core/__tests__/conditions.test.ts
@@ -1,0 +1,134 @@
+// src/core/__tests__/conditions.test.ts
+// Tests for condition detection + override precedence + unmet-condition lookup.
+
+import { describe, it, expect } from "vitest";
+import { evaluateConditions, firstUnmetCondition } from "../conditions.js";
+import type { InputManifest } from "../../schemas/index.js";
+
+function makeManifest(files: string[] = []): Omit<InputManifest, "input_hash"> {
+  return {
+    manifest_version: "1.0.0",
+    created_at: "2024-01-01T00:00:00.000Z",
+    repository_path: "/test/repo",
+    git_commit: "abc123",
+    git_branch: "main",
+    git_dirty: false,
+    standards_version: "7.0.0",
+    standards_config_hash: "test-hash",
+    files: files.map((path) => ({
+      path,
+      hash: "hash",
+      size: 0,
+      mtime: "2024-01-01T00:00:00.000Z",
+    })),
+  };
+}
+
+describe("evaluateConditions", () => {
+  // Using a path that doesn't exist on disk keeps existsSync() from firing.
+  const repoPath = "/nonexistent/test-repo";
+
+  describe("has-database detection", () => {
+    it("true when a migrations/ directory is present", () => {
+      const manifest = makeManifest(["migrations/001_init.sql"]);
+      const result = evaluateConditions(repoPath, manifest);
+      expect(result["has-database"]).toBe(true);
+    });
+
+    it("true when prisma/schema.prisma is present", () => {
+      const manifest = makeManifest(["prisma/schema.prisma"]);
+      const result = evaluateConditions(repoPath, manifest);
+      expect(result["has-database"]).toBe(true);
+    });
+
+    it("true when db/migrate/ directory is present", () => {
+      const manifest = makeManifest(["db/migrate/20240101_create.rb"]);
+      const result = evaluateConditions(repoPath, manifest);
+      expect(result["has-database"]).toBe(true);
+    });
+
+    it("false when no database markers are present", () => {
+      const manifest = makeManifest(["src/index.ts", "README.md"]);
+      const result = evaluateConditions(repoPath, manifest);
+      expect(result["has-database"]).toBe(false);
+    });
+  });
+
+  describe("has-cli detection", () => {
+    it("true when src/cli.ts is present", () => {
+      const manifest = makeManifest(["src/cli.ts"]);
+      const result = evaluateConditions(repoPath, manifest);
+      expect(result["has-cli"]).toBe(true);
+    });
+
+    it("true when a top-level cli/ directory is present", () => {
+      const manifest = makeManifest(["cli/main.ts"]);
+      const result = evaluateConditions(repoPath, manifest);
+      expect(result["has-cli"]).toBe(true);
+    });
+
+    it("false when no CLI markers are present", () => {
+      const manifest = makeManifest(["src/index.ts", "README.md"]);
+      const result = evaluateConditions(repoPath, manifest);
+      expect(result["has-cli"]).toBe(false);
+    });
+  });
+
+  describe("override precedence", () => {
+    it("override=true forces true even when detection would say false", () => {
+      const manifest = makeManifest(["src/index.ts"]); // no markers
+      const result = evaluateConditions(repoPath, manifest, {
+        "has-database": true,
+      });
+      expect(result["has-database"]).toBe(true);
+    });
+
+    it("override=false forces false even when detection would say true", () => {
+      const manifest = makeManifest(["migrations/001_init.sql"]); // marker present
+      const result = evaluateConditions(repoPath, manifest, {
+        "has-database": false,
+      });
+      expect(result["has-database"]).toBe(false);
+    });
+
+    it("unrelated override leaves auto-detection untouched", () => {
+      const manifest = makeManifest(["migrations/001_init.sql"]);
+      const result = evaluateConditions(repoPath, manifest, {
+        "has-cli": true,
+      });
+      expect(result["has-database"]).toBe(true);
+      expect(result["has-cli"]).toBe(true);
+    });
+  });
+});
+
+describe("firstUnmetCondition", () => {
+  const allMet = { "has-database": true, "has-cli": true };
+  const dbOnly = { "has-database": true, "has-cli": false };
+
+  it("returns null when the item has no conditions", () => {
+    expect(firstUnmetCondition(undefined, allMet)).toBeNull();
+    expect(firstUnmetCondition([], allMet)).toBeNull();
+  });
+
+  it("returns null when all listed conditions are met", () => {
+    expect(firstUnmetCondition(["has-database"], allMet)).toBeNull();
+    expect(firstUnmetCondition(["has-database", "has-cli"], allMet)).toBeNull();
+  });
+
+  it("returns the first unmet condition name when one is missing", () => {
+    expect(firstUnmetCondition(["has-cli"], dbOnly)).toBe("has-cli");
+  });
+
+  it("returns the first unmet condition when multiple are listed", () => {
+    expect(firstUnmetCondition(["has-database", "has-cli"], dbOnly)).toBe(
+      "has-cli",
+    );
+  });
+
+  it("treats unknown conditions as unmet", () => {
+    expect(firstUnmetCondition(["unknown-condition"], allMet)).toBe(
+      "unknown-condition",
+    );
+  });
+});

--- a/src/core/conditions.ts
+++ b/src/core/conditions.ts
@@ -1,0 +1,168 @@
+// src/core/conditions.ts
+// Repository-state predicates used by the rule engine to decide whether a
+// conditional checklist item applies. Items opt in via `conditions: ["..."]`.
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { InputManifest } from "../schemas/index.js";
+
+/**
+ * Known conditions recognized by the rule engine. Items reference these by
+ * name via the `conditions` field on a ChecklistItem. Conditions combine
+ * with AND semantics: an item applies only if *every* listed condition is
+ * true.
+ *
+ * To add a condition:
+ *   1. Add the name here.
+ *   2. Implement a detector in DETECTORS below.
+ *   3. Document the detection heuristic in the JSDoc above that detector.
+ *
+ * Unknown condition names always evaluate to false (items referencing them
+ * will always render as N/A). This is intentional: typos fail loud.
+ */
+export const KNOWN_CONDITIONS = ["has-database", "has-cli"] as const;
+
+export type ConditionName = (typeof KNOWN_CONDITIONS)[number];
+
+type ConditionDetector = (
+  repoPath: string,
+  manifest: Omit<InputManifest, "input_hash">,
+) => boolean;
+
+function anyFileExists(
+  repoPath: string,
+  manifest: Omit<InputManifest, "input_hash">,
+  candidates: string[],
+): boolean {
+  for (const file of candidates) {
+    const normalized = file.replace(/\\/g, "/");
+    if (manifest.files.some((f) => f.path === normalized)) return true;
+    if (existsSync(join(repoPath, file))) return true;
+  }
+  return false;
+}
+
+function hasDirectory(
+  manifest: Omit<InputManifest, "input_hash">,
+  prefix: string,
+): boolean {
+  const normalized = prefix.replace(/\\/g, "/").replace(/\/$/, "") + "/";
+  return manifest.files.some((f) => f.path.startsWith(normalized));
+}
+
+function packageJsonHasBin(repoPath: string): boolean {
+  const packageJsonPath = join(repoPath, "package.json");
+  if (!existsSync(packageJsonPath)) return false;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const bin = pkg.bin as unknown;
+    if (typeof bin === "string" && bin.length > 0) return true;
+    if (
+      typeof bin === "object" &&
+      bin !== null &&
+      Object.keys(bin).length > 0
+    ) {
+      return true;
+    }
+  } catch {
+    // Malformed package.json — treat as no bin.
+  }
+  return false;
+}
+
+/**
+ * has-database: true when the repo ships a relational schema with migrations.
+ * Heuristics (any one suffices):
+ *   - a `migrations/` directory (any stack)
+ *   - a `db/migrate/` directory (Rails / similar)
+ *   - `alembic.ini` (Python / SQLAlchemy)
+ *   - `prisma/schema.prisma` (Prisma)
+ *   - `drizzle.config.{ts,js,json}` (Drizzle)
+ *   - `knexfile.{js,ts,cjs}` (Knex)
+ */
+const detectHasDatabase: ConditionDetector = (repoPath, manifest) => {
+  if (hasDirectory(manifest, "migrations")) return true;
+  if (hasDirectory(manifest, "db/migrate")) return true;
+  return anyFileExists(repoPath, manifest, [
+    "alembic.ini",
+    "prisma/schema.prisma",
+    "drizzle.config.ts",
+    "drizzle.config.js",
+    "drizzle.config.json",
+    "knexfile.js",
+    "knexfile.ts",
+    "knexfile.cjs",
+  ]);
+};
+
+/**
+ * has-cli: true when the repo ships a command-line entrypoint.
+ * Heuristics (any one suffices):
+ *   - `package.json` has a non-empty `bin` field (Node)
+ *   - a `src/cli.{ts,js,py}` file (common convention)
+ *   - a top-level `cli/` or `cmd/` directory
+ */
+const detectHasCli: ConditionDetector = (repoPath, manifest) => {
+  if (packageJsonHasBin(repoPath)) return true;
+  if (
+    anyFileExists(repoPath, manifest, [
+      "src/cli.ts",
+      "src/cli.js",
+      "src/cli.py",
+      "src/cli.mjs",
+      "src/cli.cjs",
+    ])
+  ) {
+    return true;
+  }
+  if (hasDirectory(manifest, "cli")) return true;
+  if (hasDirectory(manifest, "cmd")) return true;
+  return false;
+};
+
+const DETECTORS: Record<ConditionName, ConditionDetector> = {
+  "has-database": detectHasDatabase,
+  "has-cli": detectHasCli,
+};
+
+/**
+ * Evaluate all known conditions against a repository.
+ *
+ * Precedence: if a condition name appears in `overrides`, its value is used
+ * as-is regardless of detection. Otherwise the detector runs. Unknown
+ * condition names are not evaluated here (they will read `false` from the
+ * returned record because the key is absent).
+ */
+export function evaluateConditions(
+  repoPath: string,
+  manifest: Omit<InputManifest, "input_hash">,
+  overrides?: Record<string, boolean>,
+): Record<string, boolean> {
+  const result: Record<string, boolean> = {};
+  for (const name of KNOWN_CONDITIONS) {
+    if (overrides && name in overrides) {
+      result[name] = Boolean(overrides[name]);
+    } else {
+      result[name] = DETECTORS[name](repoPath, manifest);
+    }
+  }
+  return result;
+}
+
+/**
+ * Given an item's `conditions` list and the evaluated condition map, return
+ * the name of the first unmet condition, or null if all conditions hold.
+ * Unknown conditions (not in the evaluated map) are treated as unmet.
+ */
+export function firstUnmetCondition(
+  itemConditions: string[] | undefined,
+  evaluated: Record<string, boolean>,
+): string | null {
+  if (!itemConditions || itemConditions.length === 0) return null;
+  for (const cond of itemConditions) {
+    if (!evaluated[cond]) return cond;
+  }
+  return null;
+}

--- a/src/core/config-loader.ts
+++ b/src/core/config-loader.ts
@@ -40,6 +40,13 @@ export interface StandardsConfig {
   /** Custom exclusions */
   exclude?: string[];
 
+  /**
+   * Explicit condition overrides keyed by condition name (e.g., "has-database").
+   * When present, overrides the rule engine's auto-detection for that
+   * condition. Undefined values fall through to auto-detection.
+   */
+  conditions?: Record<string, boolean>;
+
   /** Raw TOML content hash for determinism */
   config_hash: string;
 }
@@ -101,12 +108,24 @@ export function loadStandardsConfig(repoPath: string): StandardsConfig {
       }))
     : DEFAULT_CONFIG.packs;
 
+  // Parse [conditions] override table. Values are coerced to booleans so
+  // non-boolean TOML values (e.g., strings) don't silently pass through.
+  const conditionsRaw = parsed.conditions as
+    | Record<string, unknown>
+    | undefined;
+  const conditions: Record<string, boolean> | undefined = conditionsRaw
+    ? Object.fromEntries(
+        Object.entries(conditionsRaw).map(([k, v]) => [k, Boolean(v)]),
+      )
+    : undefined;
+
   return {
     version,
     stack,
     ci_system,
     packs,
     exclude,
+    conditions,
     config_hash,
   };
 }

--- a/src/core/rule-engine.ts
+++ b/src/core/rule-engine.ts
@@ -7,15 +7,18 @@ import { v4 as uuidv4 } from "uuid";
 import type {
   Finding,
   Severity,
+  Tier,
   RemediationClass,
   RiskLevel,
   EstimatedScope,
+  NotApplicableEntry,
 } from "../schemas/index.js";
 import type { InputManifest } from "../schemas/index.js";
 import type { StandardsConfig } from "./config-loader.js";
 import type { ChecklistItem, StackHints } from "../types.js";
 // Import from internal module to avoid circular dependency with index.ts
 import { loadBaseline } from "../internal/baseline-loader.js";
+import { evaluateConditions, firstUnmetCondition } from "./conditions.js";
 
 /**
  * Result of rule evaluation.
@@ -32,6 +35,12 @@ export interface RuleEvaluationResult {
 
   /** Number of rules failed */
   rules_failed: number;
+
+  /**
+   * Items skipped because at least one declared condition was unmet.
+   * Always present (empty array when no items were skipped).
+   */
+  not_applicable: NotApplicableEntry[];
 }
 
 /**
@@ -169,6 +178,7 @@ function checkRequiredScripts(
  */
 function evaluateItem(
   item: ChecklistItem,
+  tier: Tier,
   repoPath: string,
   config: StandardsConfig,
   manifest: Omit<InputManifest, "input_hash">,
@@ -187,6 +197,7 @@ function evaluateItem(
         finding_id: uuidv4(),
         rule_id: item.id,
         severity,
+        tier,
         title: `Missing required file(s): ${item.label}`,
         description: `${item.description}\n\nMissing files: ${missing.join(", ")}`,
         remediation_class: "mechanical",
@@ -209,6 +220,7 @@ function evaluateItem(
         finding_id: uuidv4(),
         rule_id: item.id,
         severity,
+        tier,
         title: `Missing configuration: ${item.label}`,
         description: `${item.description}\n\nExpected one of: ${hints.anyOfFiles.join(", ")}`,
         remediation_class: determineRemediationClass(item, hints),
@@ -231,6 +243,7 @@ function evaluateItem(
         finding_id: uuidv4(),
         rule_id: item.id,
         severity,
+        tier,
         title: `Missing npm scripts: ${item.label}`,
         description: `${item.description}\n\nMissing scripts: ${missing.join(", ")}`,
         file_path: "package.json",
@@ -262,6 +275,7 @@ export function evaluateRules(
   manifest: Omit<InputManifest, "input_hash">,
 ): RuleEvaluationResult {
   const findings: Finding[] = [];
+  const not_applicable: NotApplicableEntry[] = [];
   let rules_evaluated = 0;
   let rules_passed = 0;
   let rules_failed = 0;
@@ -269,14 +283,31 @@ export function evaluateRules(
   // Load standards for the configured stack
   const standards = loadBaseline(config.stack, config.ci_system);
 
-  // Evaluate all checklist items
-  const allItems = [
-    ...standards.checklist.core,
-    ...standards.checklist.recommended,
-    ...standards.checklist.optionalEnhancements,
+  // Evaluate known conditions once for the whole run. Consumer overrides
+  // in config.conditions take precedence over auto-detection.
+  const conditionStates = evaluateConditions(
+    repoPath,
+    manifest,
+    config.conditions,
+  );
+
+  // Evaluate all checklist items, preserving tier from array placement
+  const allItems: Array<{ item: ChecklistItem; tier: Tier }> = [
+    ...standards.checklist.core.map((item) => ({
+      item,
+      tier: "core" as const,
+    })),
+    ...standards.checklist.recommended.map((item) => ({
+      item,
+      tier: "recommended" as const,
+    })),
+    ...standards.checklist.optionalEnhancements.map((item) => ({
+      item,
+      tier: "optional" as const,
+    })),
   ];
 
-  for (const item of allItems) {
+  for (const { item, tier } of allItems) {
     // Check if item applies to this stack
     // If appliesTo.stacks is defined, the stack must be in the list
     // If appliesTo.stacks is undefined, item applies to all stacks
@@ -298,9 +329,21 @@ export function evaluateRules(
       continue;
     }
 
+    // Check declared conditions. Items whose conditions are unmet are
+    // recorded as not-applicable rather than evaluated as failing.
+    const unmet = firstUnmetCondition(item.conditions, conditionStates);
+    if (unmet !== null) {
+      not_applicable.push({
+        rule_id: item.id,
+        tier,
+        unmet_condition: unmet,
+      });
+      continue;
+    }
+
     rules_evaluated++;
 
-    const finding = evaluateItem(item, repoPath, config, manifest);
+    const finding = evaluateItem(item, tier, repoPath, config, manifest);
     if (finding) {
       findings.push(finding);
       rules_failed++;
@@ -314,5 +357,6 @@ export function evaluateRules(
     rules_evaluated,
     rules_passed,
     rules_failed,
+    not_applicable,
   };
 }

--- a/src/schemas/finding.ts
+++ b/src/schemas/finding.ts
@@ -10,6 +10,15 @@
 export type Severity = "error" | "warn" | "info";
 
 /**
+ * Tier of the checklist item that produced this finding.
+ * Determined by which checklist array the item was placed in.
+ * - core: Must-have patterns; failing items are errors by default.
+ * - recommended: Should-have patterns; failing items are warnings by default.
+ * - optional: Nice-to-have patterns for hardened repos.
+ */
+export type Tier = "core" | "recommended" | "optional";
+
+/**
  * Classification of how a finding should be remediated.
  * - mechanical: Can be fixed automatically with deterministic rules
  * - ai: Requires AI assistance for intelligent remediation
@@ -47,6 +56,9 @@ export interface Finding {
 
   /** Severity of the violation */
   severity: Severity;
+
+  /** Tier of the checklist item that produced this finding */
+  tier: Tier;
 
   /** Short title describing the finding */
   title: string;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -3,13 +3,18 @@
 
 export type {
   Severity,
+  Tier,
   RemediationClass,
   RiskLevel,
   EstimatedScope,
   Finding,
 } from "./finding.js";
 
-export type { VerifySummary, VerifyResult } from "./verify-result.js";
+export type {
+  NotApplicableEntry,
+  VerifySummary,
+  VerifyResult,
+} from "./verify-result.js";
 
 export type {
   SessionPhase,

--- a/src/schemas/verify-result.ts
+++ b/src/schemas/verify-result.ts
@@ -1,7 +1,23 @@
 // src/schemas/verify-result.ts
 // VerifyResult schema v1.1.0 - structured output from verify command
 
-import type { Finding, Severity, RemediationClass } from "./finding.js";
+import type { Finding, Severity, RemediationClass, Tier } from "./finding.js";
+
+/**
+ * An item that was not evaluated because at least one of its declared
+ * conditions was not met. Surfaced to consumers so they can see which
+ * checks were deliberately skipped (vs. silently omitted).
+ */
+export interface NotApplicableEntry {
+  /** Rule identifier of the skipped item */
+  rule_id: string;
+
+  /** Tier of the skipped item */
+  tier: Tier;
+
+  /** Name of the first unmet condition that caused the skip */
+  unmet_condition: string;
+}
 
 /**
  * Summary of findings by category.
@@ -15,6 +31,9 @@ export interface VerifySummary {
 
   /** Count of findings by remediation class */
   by_remediation_class: Record<RemediationClass, number>;
+
+  /** Count of findings by tier (core / recommended / optional) */
+  by_tier: Record<Tier, number>;
 }
 
 /**
@@ -53,6 +72,12 @@ export interface VerifyResult {
 
   /** List of compliance violations found */
   findings: Finding[];
+
+  /**
+   * Items that were not evaluated because at least one declared condition
+   * was not met. Always present (empty array when no items were skipped).
+   */
+  not_applicable: NotApplicableEntry[];
 
   /** Summary statistics for findings */
   summary: VerifySummary;

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,15 @@ export type Enforcement = "required" | "recommended" | "optional";
  */
 export type Severity = "error" | "warn" | "info";
 
+/**
+ * Implementation maturity of a checklist item.
+ * Signals to consumers whether the pattern is ready-to-copy or still documented-only.
+ * - documented: Described in instructions/docs; no template shipped yet.
+ * - template-planned: Template scheduled for a named milestone, not yet written.
+ * - template-available: Template exists under templates/patterns/<id>/; consumers can copy-and-adapt.
+ */
+export type Maturity = "documented" | "template-planned" | "template-available";
+
 /** Migration guide step for onboarding repositories */
 export interface MigrationStep {
   step: number;
@@ -123,6 +132,17 @@ export interface ChecklistItem {
   id: string;
   label: string;
   description: string;
+  /**
+   * Implementation maturity — lets consumers tell documented-only patterns
+   * from ready-to-copy ones. Required on every item.
+   */
+  maturity: Maturity;
+  /**
+   * Optional condition predicates (e.g., "has-database", "has-cli") that
+   * gate applicability. If any condition is unmet, the item evaluates as
+   * N/A in verify output. Detection is handled by the rule engine.
+   */
+  conditions?: string[];
   enforcement?: Enforcement;
   severity?: Severity;
   appliesTo: {

--- a/src/version.ts
+++ b/src/version.ts
@@ -7,5 +7,5 @@
  * ESM/CJS interop issues.
  */
 
-export const STANDARDS_VERSION = "7.1.0";
+export const STANDARDS_VERSION = "7.1.1";
 export const STANDARDS_SCHEMA_VERSION = 7;

--- a/templates/patterns/README.md
+++ b/templates/patterns/README.md
@@ -1,0 +1,69 @@
+# Pattern templates
+
+Reference implementations for quality-gate patterns catalogued in
+`config/standards.json`. Consumers copy-and-adapt these into their own repos
+when the corresponding checklist item has `maturity: "template-available"`.
+
+## Directory layout
+
+```
+templates/patterns/
+  <pattern-id>/
+    README.md                 # pattern intent + integration + meta-principles footer
+    python/                   # reference implementation (when stack-applicable)
+      ...
+    typescript/               # reference implementation OR concept-only README
+      ...
+```
+
+One subdirectory per catalog item; the directory name equals the item's `id`
+field in `config/standards.json`.
+
+## Required README content
+
+Every `<pattern-id>/README.md` MUST contain:
+
+1. **Intent.** What the pattern does and which defect class it prevents —
+   phrased generically, without naming origin projects, commit SHAs, or issue
+   numbers in the body text.
+2. **Integration shape.** What the consumer wires up, where the gate runs
+   (pre-commit / pre-push / CI), and what the failure mode looks like.
+3. **Scope-discipline note where applicable.** For patterns whose test locks a
+   narrow surface (canonical identifier presence, a single seed integer, etc.),
+   call out the lock surface explicitly so future extenders don't widen it.
+   Patterns citing `mp-churn-bait-discipline` in the footer MUST carry a
+   "Scope discipline" anchor; the footer gate enforces this.
+4. **Provenance (one line, optional).** If the template is adapted from an
+   external source, a single line of the form `adapted from <source>@<sha>`
+   near the top. This is the ONLY place in the repo where origin-project names
+   are permitted.
+5. **Meta-principles footer.** A terminal section of the form:
+
+   ```markdown
+   ## Design principles this template obeys
+
+   This pattern follows: `mp-...`, `mp-...` — see
+   [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.
+   ```
+
+   At least one `mp-*` principle must be cited. Every cited ID must exist in
+   `docs/patterns/meta-principles.md` (the authoritative set).
+
+## Enforcement
+
+`scripts/verify-pattern-footers.ts` runs on every `npm run test` invocation.
+It rejects any `<pattern-id>/README.md` that lacks the footer section, cites
+zero `mp-*` principles, references a typo'd principle, or cites
+`mp-churn-bait-discipline` without a "Scope discipline" anchor.
+
+New meta-principles added under `docs/patterns/meta-principles.md` are picked
+up automatically — the gate parses the authoritative set from that doc.
+
+## Stack coverage convention
+
+Python and TypeScript are the lead implementation stacks. Where a pattern is
+listed in `config/standards.json` with `appliesTo.stacks` including multiple
+stacks but the catalog entry notes `All (concept); <stack> (impl)`, ship a
+working reference for the implementation stack only. Other stacks receive a
+README that describes the shape of the port (which ecosystem tool to use,
+where to place the gate) rather than a skeleton that will drift.

--- a/templates/patterns/p-migration-ddl-parity/README.md
+++ b/templates/patterns/p-migration-ddl-parity/README.md
@@ -1,0 +1,64 @@
+# `p-migration-ddl-parity`
+
+Structural-equivalence test asserting that a DB built fresh from the canonical schema source has the same tables, columns, constraints, and indexes as a DB built by running every registered migration against the oldest-supported seed. Catches semantic drift between the inline schema and the incremental migration chain.
+
+_Adapted from `oddessentials/ado-git-repo-insights@9d2d2087` (conceptual; no direct reference test in source)._
+
+## Defect class prevented
+
+`SCHEMA_SQL` and the migration chain are two independent expressions of the same intent. They drift silently:
+
+- A column was added to `SCHEMA_SQL` with `NOT NULL` and a default value, but the migration that introduces it omits the constraint. Fresh databases reject null writes; legacy databases accept them. Production writes from the same code succeed against some tenants and fail against others.
+- An index was added to `SCHEMA_SQL` for query-plan reasons. The migration didn't create it. Fresh DBs have the index; legacy DBs scan. Performance regressions appear only on legacy tenants.
+- A foreign key was added to `SCHEMA_SQL`. The migration `ALTER`s the table but SQLite's limited `ALTER` support means the FK was silently dropped. Fresh DBs enforce; legacy DBs don't.
+
+[`p-schema-migration-parity`](../p-schema-migration-parity/) catches missing _tables_. This pattern catches drift _within_ a table.
+
+## How the pattern works
+
+Two materializations, one structural diff:
+
+1. **Fresh-schema snapshot.** Materialize `SCHEMA_SQL` in an in-memory SQLite DB. Walk every table and capture per-table PRAGMA output: `table_info` (columns), `index_list` + `index_info` (indexes). Normalize so the snapshot is order-insensitive where order is cosmetic (column declaration order) and order-sensitive where order is meaningful (column order within a composite index).
+2. **Migrated-chain snapshot.** Seed a temp DB with the v1 schema, run the production `DatabaseManager.connect()` so the real migration chain applies, then snapshot the same way.
+3. **Diff.** Same tables, same columns per table (by name → type/null/default/pk tuple), same indexes per table (by name → unique/partial/columns tuple). Any divergence is a drift; fail with a per-table breakdown of what differs and in which direction.
+
+The test runs at `ci-pr` execution stage. Pair with [`p-schema-migration-parity`](../p-schema-migration-parity/) — the pair covers both table-presence and within-table structural drift.
+
+## Integration
+
+Three hooks the test assumes (identical to [`p-schema-migration-parity`](../p-schema-migration-parity/)):
+
+| Hook                        | Shape                                               | Purpose                      |
+| --------------------------- | --------------------------------------------------- | ---------------------------- |
+| `SCHEMA_SQL` constant       | `str` of `CREATE TABLE` / `CREATE INDEX` statements | Canonical declared schema    |
+| `V1_SCHEMA_SQL` constant    | `str` of the oldest-supported schema                | Migration seed               |
+| `DatabaseManager.connect()` | runs migration chain                                | Builds the migrated snapshot |
+
+See [`python/`](./python/) for the runnable reference. Copy `test_migration_ddl_parity.py` into your test suite and re-point the `from . import reference_*` imports at your own persistence module.
+
+## Scope discipline
+
+**This test locks PRAGMA-level structural equivalence — not raw DDL text.** It must NOT be extended to:
+
+- compare raw `CREATE TABLE` / `CREATE INDEX` strings,
+- diff whitespace or comment layout,
+- assert column declaration order (that's cosmetic — SQLite preserves it but rebuilding the table via `ALTER` can change it without semantic impact),
+- assert auto-generated internal index names (`sqlite_autoindex_*`).
+
+Raw DDL comparison is classic churn bait: semantically-equivalent statements render as different text under different tools (fresh CREATE vs. `ALTER TABLE ... ADD COLUMN` re-creates), the test fails on unrelated whitespace churn, consumers bypass it, and the real defect class (semantic drift) stops being protected. Keep the lock on structural PRAGMA output so unrelated formatting cannot trip it.
+
+If you need to lock raw DDL text for a specific reason (e.g., vendor-emitted SQL that must be byte-identical for a specific tool), ship it as a separate test with its own name. Do not widen this one.
+
+## Stack coverage
+
+- **Python (runnable reference):** [`python/`](./python/) — SQLite `PRAGMA table_info` / `PRAGMA index_list` / `PRAGMA index_info` with a normalized snapshot function. Both happy-path and red-path tests included.
+- **TypeScript (concept-only):** [`typescript/`](./typescript/) — pointers for adapting via `better-sqlite3` (SQLite) or `pg-mem` (Postgres) introspection.
+
+## Adversarial tests included
+
+1. `test_detects_schema_drift` (fabricated-regression) — constructs a drifted copy of `SCHEMA_SQL` with a `NOT NULL` constraint stripped and asserts the gate reports the column difference by table + column name.
+2. `test_detects_missing_index` (fabricated-regression) — appends a `CREATE INDEX` to a copy of `SCHEMA_SQL` and asserts the gate names the missing index in the failure message.
+
+## Design principles this template obeys
+
+This pattern follows: `mp-adversarial-proof-required`, `mp-churn-bait-discipline`, `mp-point-in-time-structural-claims` — see [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.

--- a/templates/patterns/p-migration-ddl-parity/python/__init__.py
+++ b/templates/patterns/p-migration-ddl-parity/python/__init__.py
@@ -1,0 +1,9 @@
+"""Runnable reference for the p-migration-ddl-parity pattern.
+
+The reference persistence modules here are intentionally duplicated from
+sibling persistence templates (p-schema-migration-parity,
+p-required-tables-runtime-check, etc.) so each template is self-contained
+for copy-and-adapt. Consumers typically copy
+``test_migration_ddl_parity.py`` into their own test suite and re-point
+imports at their project's persistence module.
+"""

--- a/templates/patterns/p-migration-ddl-parity/python/reference_database.py
+++ b/templates/patterns/p-migration-ddl-parity/python/reference_database.py
@@ -1,0 +1,42 @@
+"""Reference DatabaseManager — runs the migration chain on connect."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from .reference_migrations import MIGRATIONS
+
+FUNDAMENTAL_TABLES: frozenset[str] = frozenset({"users"})
+REQUIRED_TABLES: frozenset[str] = frozenset({"users", "sessions", "audit_log"})
+
+
+class DatabaseManager:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.connection: sqlite3.Connection | None = None
+
+    def connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path))
+        self._apply_migrations(conn)
+        self.connection = conn
+        return conn
+
+    def close(self) -> None:
+        if self.connection is not None:
+            self.connection.close()
+            self.connection = None
+
+    @staticmethod
+    def _current_version(conn: sqlite3.Connection) -> int:
+        row = conn.execute("PRAGMA user_version").fetchone()
+        return int(row[0]) if row else 0
+
+    def _apply_migrations(self, conn: sqlite3.Connection) -> None:
+        current = self._current_version(conn)
+        for migration in MIGRATIONS:
+            if migration.target_version <= current:
+                continue
+            migration.apply(conn)
+            conn.execute(f"PRAGMA user_version = {migration.target_version}")
+        conn.commit()

--- a/templates/patterns/p-migration-ddl-parity/python/reference_migrations.py
+++ b/templates/patterns/p-migration-ddl-parity/python/reference_migrations.py
@@ -1,0 +1,49 @@
+"""Ordered migration registry. Must produce a DB structurally equivalent
+to SCHEMA_SQL when applied against a v1 seed — that's the invariant this
+template's parity test enforces.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+
+@dataclass(frozen=True)
+class Migration:
+    target_version: int
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            expires_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+        """
+    )
+
+
+def _migrate_v2_to_v3(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id INTEGER PRIMARY KEY,
+            actor_id INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            occurred_at TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_audit_log_actor_id ON audit_log(actor_id);
+        """
+    )
+
+
+MIGRATIONS: Tuple[Migration, ...] = (
+    Migration(target_version=2, apply=_migrate_v1_to_v2),
+    Migration(target_version=3, apply=_migrate_v2_to_v3),
+)

--- a/templates/patterns/p-migration-ddl-parity/python/reference_schema.py
+++ b/templates/patterns/p-migration-ddl-parity/python/reference_schema.py
@@ -1,0 +1,37 @@
+"""Canonical schema source."""
+
+from __future__ import annotations
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    expires_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY,
+    actor_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    occurred_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_actor_id ON audit_log(actor_id);
+"""
+
+SCHEMA_VERSION_SEED = 3
+
+V1_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+"""

--- a/templates/patterns/p-migration-ddl-parity/python/test_migration_ddl_parity.py
+++ b/templates/patterns/p-migration-ddl-parity/python/test_migration_ddl_parity.py
@@ -1,0 +1,280 @@
+"""DDL structural parity: fresh SCHEMA_SQL ≡ migrated-from-v1 chain.
+
+Defect class prevented
+----------------------
+``SCHEMA_SQL`` and the migration chain are two independent expressions of
+the same intent. They drift silently:
+
+- Column added to ``SCHEMA_SQL`` with ``NOT NULL``; migration omits the
+  constraint. Fresh DBs reject null writes; legacy DBs accept them.
+- Index declared in ``SCHEMA_SQL``; migration forgets to create it. Fresh
+  DBs have the index; legacy DBs full-scan.
+- Foreign key added to ``SCHEMA_SQL``; migration's ``ALTER TABLE`` path
+  silently drops the FK. Fresh DBs enforce; legacy DBs don't.
+
+This test walks every table via ``PRAGMA`` and compares the two
+materializations structurally.
+
+Scope discipline
+----------------
+This test locks **PRAGMA-level structural equivalence** — not raw DDL text.
+It must NOT be extended to compare ``CREATE TABLE`` / ``CREATE INDEX``
+strings, diff whitespace, assert column declaration order, or assert
+auto-generated index names (``sqlite_autoindex_*``).
+
+Raw DDL comparison is classic churn bait: semantically-equivalent
+statements render as different text under different tools, the test fails
+on unrelated formatting, consumers bypass it, the real defect class
+(semantic drift) stops being protected.
+
+(See ``mp-churn-bait-discipline``.)
+
+Adaptation
+----------
+Copy this file into your test suite and adjust the imports. Required hooks:
+
+- ``SCHEMA_SQL: str`` — canonical declared schema
+- ``V1_SCHEMA_SQL: str`` — oldest-supported seed
+- ``DatabaseManager.connect()`` — runs the registered migration chain
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from . import reference_schema
+from .reference_database import DatabaseManager
+
+
+ColumnTuple = Tuple[str, str, int, Any, int]
+# (name, type, notnull, default, pk) — cid is dropped (declaration order
+# artifact, not semantic).
+
+
+def _pragma_table_info(conn: sqlite3.Connection, table: str) -> List[ColumnTuple]:
+    """Return column definitions as a sorted list (order-insensitive).
+
+    Dropping ``cid`` (declaration order) so two tables with the same
+    columns in different order compare equal. Column order is cosmetic in
+    SQLite unless you care about ``SELECT *`` column-position — that's a
+    workload contract, not a schema invariant, so we leave it out.
+    """
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    columns: List[ColumnTuple] = [tuple(row[1:]) for row in rows]
+    return sorted(columns)
+
+
+def _pragma_index_list(
+    conn: sqlite3.Connection, table: str
+) -> List[Tuple[str, int, int]]:
+    """User-created indexes on the table (excluding auto-indexes).
+
+    ``origin='c'`` means ``CREATE INDEX`` — i.e., user-defined. ``'u'`` is
+    ``UNIQUE`` constraint-derived, ``'pk'`` is primary-key-derived. Those
+    are structurally implied by the column definitions we already captured
+    via ``PRAGMA table_info`` and comparing them again is redundant noise.
+    """
+    rows = conn.execute(f"PRAGMA index_list({table})").fetchall()
+    return sorted((row[1], row[2], row[4]) for row in rows if row[3] == "c")
+
+
+def _pragma_index_info(
+    conn: sqlite3.Connection, index_name: str
+) -> List[str]:
+    """Column names in an index, in declaration order.
+
+    Column order IS meaningful here — ``INDEX (a, b)`` ≠ ``INDEX (b, a)``
+    for query-plan purposes. Returned in seqno order.
+    """
+    rows = conn.execute(f"PRAGMA index_info({index_name})").fetchall()
+    return [row[2] for row in sorted(rows, key=lambda r: r[0])]
+
+
+def _enumerate_tables(conn: sqlite3.Connection) -> List[str]:
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    )
+    return sorted(row[0] for row in cursor.fetchall())
+
+
+def _snapshot(conn: sqlite3.Connection) -> Dict[str, Dict[str, Any]]:
+    """Structural snapshot: ``{table: {"columns": [...], "indexes": {name: {...}}}}``."""
+    snapshot: Dict[str, Dict[str, Any]] = {}
+    for table in _enumerate_tables(conn):
+        indexes: Dict[str, Dict[str, Any]] = {}
+        for idx_name, unique, partial in _pragma_index_list(conn, table):
+            indexes[idx_name] = {
+                "unique": unique,
+                "partial": partial,
+                "columns": _pragma_index_info(conn, idx_name),
+            }
+        snapshot[table] = {
+            "columns": _pragma_table_info(conn, table),
+            "indexes": indexes,
+        }
+    return snapshot
+
+
+def _fresh_schema_snapshot(schema_sql: str) -> Dict[str, Dict[str, Any]]:
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(schema_sql)
+        return _snapshot(conn)
+    finally:
+        conn.close()
+
+
+def _migrated_chain_snapshot(tmp_path: Path) -> Dict[str, Dict[str, Any]]:
+    db_path = tmp_path / "migrated.db"
+    seed = sqlite3.connect(str(db_path))
+    try:
+        seed.executescript(reference_schema.V1_SCHEMA_SQL)
+    finally:
+        seed.close()
+    manager = DatabaseManager(db_path)
+    manager.connect()
+    try:
+        assert manager.connection is not None
+        return _snapshot(manager.connection)
+    finally:
+        manager.close()
+
+
+def _compute_diff(
+    fresh: Dict[str, Dict[str, Any]], migrated: Dict[str, Dict[str, Any]]
+) -> Tuple[List[str], List[str]]:
+    """Return ``(drift_identifiers, message_lines)``."""
+    drift: List[str] = []
+    lines: List[str] = []
+
+    for table in sorted(set(fresh) | set(migrated)):
+        if table not in fresh:
+            drift.append(f"{table}:table")
+            lines.append(f"  table '{table}' only in migrated DB")
+            continue
+        if table not in migrated:
+            drift.append(f"{table}:table")
+            lines.append(f"  table '{table}' only in fresh-schema DB")
+            continue
+        if fresh[table]["columns"] != migrated[table]["columns"]:
+            drift.append(f"{table}:columns")
+            lines.append(
+                f"  '{table}' columns differ:\n"
+                f"    fresh:    {fresh[table]['columns']!r}\n"
+                f"    migrated: {migrated[table]['columns']!r}"
+            )
+        fresh_idx = set(fresh[table]["indexes"])
+        migrated_idx = set(migrated[table]["indexes"])
+        if fresh_idx != migrated_idx:
+            drift.append(f"{table}:indexes")
+            only_fresh = sorted(fresh_idx - migrated_idx)
+            only_migrated = sorted(migrated_idx - fresh_idx)
+            if only_fresh:
+                lines.append(
+                    f"  '{table}' indexes only in fresh-schema DB: {only_fresh}"
+                )
+            if only_migrated:
+                lines.append(
+                    f"  '{table}' indexes only in migrated DB: {only_migrated}"
+                )
+        for idx_name in sorted(fresh_idx & migrated_idx):
+            if (
+                fresh[table]["indexes"][idx_name]
+                != migrated[table]["indexes"][idx_name]
+            ):
+                drift.append(f"{table}:indexes:{idx_name}")
+                lines.append(
+                    f"  '{table}' index '{idx_name}' shape differs:\n"
+                    f"    fresh:    {fresh[table]['indexes'][idx_name]!r}\n"
+                    f"    migrated: {migrated[table]['indexes'][idx_name]!r}"
+                )
+    return drift, lines
+
+
+def _check_ddl_parity(
+    schema_sql: str, tmp_path: Path
+) -> Tuple[List[str], str]:
+    """Return ``(drift_identifiers, formatted_message)``.
+
+    Empty ``drift_identifiers`` means parity holds. When non-empty, callers
+    raise ``message`` as the assertion failure; the wording is the single
+    source of truth so happy-path and red-path tests cannot drift.
+    """
+    fresh = _fresh_schema_snapshot(schema_sql)
+    migrated = _migrated_chain_snapshot(tmp_path)
+    drift, lines = _compute_diff(fresh, migrated)
+    if not drift:
+        return [], ""
+    message = (
+        "DDL structural drift between SCHEMA_SQL and migrated-from-v1 chain:\n"
+        + "\n".join(lines)
+        + "\nRemediation: update the migration that introduced the drifting "
+        "shape to match SCHEMA_SQL, or update SCHEMA_SQL to match the "
+        "migrated shape — whichever is authoritative in your project."
+    )
+    return drift, message
+
+
+class TestMigrationDdlParity:
+    """Happy path: healthy schema + migrations produce structurally equal DBs."""
+
+    def test_fresh_schema_matches_migrated_chain(self, tmp_path: Path) -> None:
+        drift, message = _check_ddl_parity(
+            reference_schema.SCHEMA_SQL, tmp_path
+        )
+        assert not drift, message
+
+
+class TestMigrationDdlParityRedPath:
+    """Adversarial tests — prove the gate fires on the regression case.
+
+    Required by ``mp-adversarial-proof-required``.
+    """
+
+    def test_detects_schema_drift(self, tmp_path: Path) -> None:
+        """Fabricated-regression: strip ``NOT NULL`` from ``users.email`` in
+        a _copy_ of ``SCHEMA_SQL`` (never mutating the constant). Confirm
+        the gate reports a column-level drift on ``users``.
+        """
+        drifted_schema = reference_schema.SCHEMA_SQL.replace(
+            "email TEXT NOT NULL UNIQUE",
+            "email TEXT UNIQUE",
+        )
+        assert drifted_schema != reference_schema.SCHEMA_SQL, (
+            "test setup bug: drifted_schema should differ from SCHEMA_SQL"
+        )
+
+        drift, message = _check_ddl_parity(drifted_schema, tmp_path)
+
+        assert "users:columns" in drift, (
+            f"gate failed to detect NOT NULL drift on users.email — got: {drift}"
+        )
+        assert "users" in message, (
+            f"gate message must name the affected table, got: {message!r}"
+        )
+        assert "columns differ" in message, (
+            f"gate message must identify the divergence type, got: {message!r}"
+        )
+
+    def test_detects_missing_index(self, tmp_path: Path) -> None:
+        """Fabricated-regression: add a ``CREATE INDEX`` to a _copy_ of
+        ``SCHEMA_SQL`` with no corresponding migration. Confirm the gate
+        names the missing index.
+        """
+        canary_index = (
+            "\nCREATE INDEX IF NOT EXISTS idx_canary_users_created "
+            "ON users(created_at);\n"
+        )
+        drift, message = _check_ddl_parity(
+            reference_schema.SCHEMA_SQL + canary_index, tmp_path
+        )
+
+        assert any(d == "users:indexes" for d in drift), (
+            f"gate failed to detect missing index on users — got: {drift}"
+        )
+        assert "idx_canary_users_created" in message, (
+            f"gate message must name the missing index, got: {message!r}"
+        )

--- a/templates/patterns/p-migration-ddl-parity/typescript/README.md
+++ b/templates/patterns/p-migration-ddl-parity/typescript/README.md
@@ -1,0 +1,41 @@
+# `p-migration-ddl-parity` — TypeScript adaptation
+
+Concept-only. DDL-parity checks are tightly coupled to both your ORM's introspection surface and your DB vendor's dialect — a generic TS skeleton cannot be honest about either.
+
+## Apply the same three-step check
+
+1. **Fresh-schema snapshot.** Build an in-memory DB from your canonical schema source (drizzle schema objects, Prisma schema, raw SQL) and introspect its structural shape.
+2. **Migrated-chain snapshot.** Seed a temp DB with your oldest-supported version, run every registered migration through your migration runner, and introspect the resulting shape.
+3. **Structural diff.** Compare tables → columns → indexes. Normalize column order (cosmetic) and keep index column order (semantic). Report per-table divergence by name, not raw DDL.
+
+## Ecosystem pointers
+
+### SQLite via `better-sqlite3`
+
+Use the same `PRAGMA table_info` / `PRAGMA index_list` / `PRAGMA index_info` queries as the Python reference. Port directly:
+
+```ts
+const columns = db.prepare(`PRAGMA table_info(${table})`).all();
+const indexes = db
+  .prepare(`PRAGMA index_list(${table})`)
+  .all()
+  .filter((i: { origin: string }) => i.origin === "c");
+```
+
+### Postgres via [`pg-mem`](https://github.com/oguimbal/pg-mem)
+
+In-memory Postgres supports enough dialect to materialize most schemas. Introspect via `information_schema.columns`, `pg_indexes`, `pg_constraint`. Normalize column order (`ordinal_position` is cosmetic here too) and keep index column order.
+
+### Drizzle ORM
+
+`drizzle-kit` can generate a snapshot JSON (`drizzle-kit generate --dialect <d>`). Running it against both the schema and the migration-applied DB gives two snapshots that diff cleanly. Prefer this over direct DB introspection when you already use drizzle — the snapshot format is stable across drizzle versions.
+
+### Prisma
+
+Use `prisma migrate diff --from-schema-datamodel=... --to-schema-datamodel=...` with the migrated DB URL. Empty diff == parity; non-empty == drift.
+
+## Scope discipline applies identically
+
+The TS version MUST NOT be extended to raw DDL text comparison. Whatever format your ecosystem uses (drizzle snapshot JSON, Prisma migration diff, raw SQL strings), treat the introspected STRUCTURE as the lock surface, not the SERIALIZED FORM. The churn-bait failure mode is identical across languages.
+
+See the [Python reference](../python/) for the canonical shape.

--- a/templates/patterns/p-migration-test-coverage/README.md
+++ b/templates/patterns/p-migration-test-coverage/README.md
@@ -1,0 +1,63 @@
+# `p-migration-test-coverage`
+
+Coverage check asserting that every migration in the registry has at least one test exercising it (a) on a blank DB and (b) on the prior schema version. Blocks untested migrations from shipping.
+
+_Adapted from `oddessentials/ado-git-repo-insights@9d2d2087` (conceptual; derived from the broader test-discipline conventions in source)._
+
+## The migration registry is the authoritative manifest
+
+This is load-bearing for the pattern and governs how the check is implemented:
+
+- **DO** iterate the registry constant (e.g., `from .migrations import MIGRATIONS`) as the source of truth for which migrations exist.
+- **DO NOT** file-scan `migrations/` directories, parse filenames, walk `__init__.py` imports, or introspect module contents.
+
+The registry is what the running app actually uses to drive upgrades. A migration that exists as a file but isn't in the registry will never run; a migration in the registry without a corresponding file will fail to import. Either way, the registry is the only set that matters — filename / file-presence checks produce false positives (tombstoned files, tooling scratch files) and false negatives (registered in-memory migrations for tests).
+
+See [`mp-committed-proof-artifacts`](../../../docs/patterns/meta-principles.md#mp-committed-proof-artifacts) — the registry is the artifact; the coverage check is the exact-match verifier.
+
+## Defect class prevented
+
+An engineer adds a migration to the registry, wires it into the production upgrade path, but ships no tests for it:
+
+- **No blank-DB test.** The fresh-install path through that migration has never run. Migration bodies contain real SQL — DROP COLUMN semantics vary between dialects, `ALTER TABLE` has edge cases, transaction boundaries interact with DDL in non-obvious ways. The first production fresh-install exercises the code for real.
+- **No prior-version test.** The legacy-upgrade path has never run. The migration may assume a table exists in a shape only fresh DBs have. Legacy tenants start upgrading and the migration raises against a structure it didn't anticipate.
+
+Both tests are required because they exercise materially different code paths — the blank-DB test runs the migration body; the prior-version test runs the migration body _against the schema the prior migration left behind_, which can differ from any engineer's mental model.
+
+## How the pattern works
+
+1. Read the registry constant. This is the authoritative list.
+2. For each `Migration(target_version=N, apply=...)`, ask:
+   - Does at least one test exist that runs this migration's `apply()` against a **blank DB**?
+   - Does at least one test exist that runs this migration's `apply()` against a **DB at schema version N-1**?
+3. The two questions are answered by consulting a per-migration coverage manifest maintained alongside the registry. The manifest maps `target_version` → `{blank_db: [test_ids...], prior_version: [test_ids...]}`. Missing or empty arrays fail the gate.
+
+Why a manifest and not "discover tests automatically": test discovery depends on file naming, class hierarchies, parametrize fixtures, and any number of ecosystem-specific conventions — none of which are reliable to introspect across projects. An explicit manifest is diffable in PR, forces the engineer to claim coverage explicitly, and fails the gate if the claim goes stale (missing test id, removed test).
+
+The check runs at `ci-pr` execution stage.
+
+## Integration
+
+| Hook                               | Shape                                                           | Purpose                                          |
+| ---------------------------------- | --------------------------------------------------------------- | ------------------------------------------------ |
+| `MIGRATIONS` registry              | `Sequence[Migration]` with `.target_version: int`               | Authoritative set of migrations                  |
+| `MIGRATION_TEST_COVERAGE` manifest | `Mapping[int, {blank_db: list[str], prior_version: list[str]}]` | Per-target-version claim of which tests cover it |
+| Test discovery                     | whatever your test framework uses                               | Manifest entries must match real test ids        |
+
+The manifest lives in the same module as the registry (or imports from it). Adding a migration means adding its manifest entry; the gate fails immediately if coverage claims are missing or empty.
+
+An optional second-level check walks the test suite and verifies every manifest-claimed test actually exists. Shipping this extra check moves the pattern from "claim is diffable" to "claim is exact-match verified" (strongest form of [`mp-committed-proof-artifacts`](../../../docs/patterns/meta-principles.md#mp-committed-proof-artifacts)).
+
+## Stack coverage
+
+- **Python (runnable reference):** [`python/`](./python/) — registry + manifest + coverage check + adversarial tests.
+- **TypeScript (concept-only):** [`typescript/`](./typescript/).
+
+## Adversarial tests included
+
+1. `test_detects_untested_migration` (fabricated-regression) — appends a migration to a copy of the registry with no manifest entry; asserts the gate names the missing `target_version` explicitly.
+2. `test_detects_partial_test_coverage` (fabricated-regression) — constructs a manifest entry with `blank_db` populated but `prior_version` empty; asserts the gate names both the migration and the missing phase.
+
+## Design principles this template obeys
+
+This pattern follows: `mp-adversarial-proof-required`, `mp-committed-proof-artifacts` — see [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.

--- a/templates/patterns/p-migration-test-coverage/python/__init__.py
+++ b/templates/patterns/p-migration-test-coverage/python/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable reference for the p-migration-test-coverage pattern."""

--- a/templates/patterns/p-migration-test-coverage/python/reference_migrations.py
+++ b/templates/patterns/p-migration-test-coverage/python/reference_migrations.py
@@ -1,0 +1,79 @@
+"""Ordered migration registry + per-migration test coverage manifest.
+
+The registry is the authoritative set. The manifest makes each migration's
+test coverage claim explicit and diffable in PR. The coverage check in
+``test_migration_test_coverage.py`` walks the registry and asserts every
+``target_version`` has populated ``blank_db`` AND ``prior_version`` arrays.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Callable, Mapping, Tuple
+
+
+@dataclass(frozen=True)
+class Migration:
+    target_version: int
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            expires_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+def _migrate_v2_to_v3(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id INTEGER PRIMARY KEY,
+            actor_id INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            occurred_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+MIGRATIONS: Tuple[Migration, ...] = (
+    Migration(target_version=2, apply=_migrate_v1_to_v2),
+    Migration(target_version=3, apply=_migrate_v2_to_v3),
+)
+
+
+MIGRATION_TEST_COVERAGE: Mapping[int, Mapping[str, Tuple[str, ...]]] = {
+    2: {
+        "blank_db": (
+            "tests.migrations.test_v1_to_v2::TestMigrateV1ToV2::test_blank_db",
+        ),
+        "prior_version": (
+            "tests.migrations.test_v1_to_v2::TestMigrateV1ToV2::test_from_v1",
+        ),
+    },
+    3: {
+        "blank_db": (
+            "tests.migrations.test_v2_to_v3::TestMigrateV2ToV3::test_blank_db",
+        ),
+        "prior_version": (
+            "tests.migrations.test_v2_to_v3::TestMigrateV2ToV3::test_from_v2",
+        ),
+    },
+}
+"""Per-migration test coverage manifest.
+
+Keys: ``target_version`` (must match a Migration in MIGRATIONS).
+Values: {``blank_db``: tuple of test ids, ``prior_version``: tuple of test ids}.
+
+Each array MUST be non-empty. Adding a migration means adding its entry.
+The check in :func:`check_migration_test_coverage` fails loudly if a
+migration has no manifest entry, has empty arrays, or if a manifest entry
+references a target_version that doesn't exist in MIGRATIONS."""

--- a/templates/patterns/p-migration-test-coverage/python/test_migration_test_coverage.py
+++ b/templates/patterns/p-migration-test-coverage/python/test_migration_test_coverage.py
@@ -1,0 +1,188 @@
+"""Every migration has blank-DB + prior-version tests claimed in the manifest.
+
+Defect class prevented
+----------------------
+An engineer wires a migration into the registry, ships it, but writes no
+tests for it. Two code paths go unverified:
+
+- The migration body running against a blank DB (fresh-install path).
+- The migration body running against the prior schema version
+  (legacy-upgrade path).
+
+Both paths exercise materially different preconditions; one test covers
+neither. This check blocks the merge on missing coverage claims.
+
+Authoritative manifest
+----------------------
+The migration registry (``MIGRATIONS``) is the authoritative set. The
+coverage manifest (``MIGRATION_TEST_COVERAGE``) claims which tests cover
+each migration. This check walks the registry and asserts:
+
+1. Every ``target_version`` in the registry has a manifest entry.
+2. Every manifest entry has non-empty ``blank_db`` and ``prior_version``
+   arrays.
+3. No manifest entry references a ``target_version`` that isn't in the
+   registry (stale entries).
+
+Do NOT file-scan ``migrations/`` directories or parse filenames. The
+registry is the only authoritative source.
+
+(See ``mp-committed-proof-artifacts``.)
+
+Adaptation
+----------
+Required hooks:
+
+- ``MIGRATIONS: Sequence[Migration]`` with ``.target_version: int``
+- ``MIGRATION_TEST_COVERAGE: Mapping[int, {"blank_db": tuple[str, ...],
+  "prior_version": tuple[str, ...]}]``
+
+Optionally add a second check that walks the real test suite and verifies
+every manifest-claimed test id resolves to an actual test. That upgrades
+the claim from "diffable" to "exact-match verified".
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Mapping, Sequence, Tuple
+
+from .reference_migrations import (
+    MIGRATION_TEST_COVERAGE,
+    MIGRATIONS,
+    Migration,
+)
+
+
+def check_migration_test_coverage(
+    migrations: Sequence[Migration],
+    manifest: Mapping[int, Mapping[str, Tuple[str, ...]]],
+) -> Tuple[List[str], str]:
+    """Return ``(failures, message)``.
+
+    Empty ``failures`` means every migration has blank + prior-version
+    coverage claimed and no stale manifest entries exist.
+    """
+    registry_versions = {m.target_version for m in migrations}
+    failures: List[str] = []
+    lines: List[str] = []
+
+    for migration in migrations:
+        version = migration.target_version
+        entry = manifest.get(version)
+        if entry is None:
+            failures.append(f"missing:{version}")
+            lines.append(
+                f"  migration target_version={version} has no MIGRATION_TEST_COVERAGE "
+                f"entry — add one claiming blank_db + prior_version test ids"
+            )
+            continue
+        for phase in ("blank_db", "prior_version"):
+            phase_tests = entry.get(phase, ())
+            if not phase_tests:
+                failures.append(f"empty:{version}:{phase}")
+                lines.append(
+                    f"  migration target_version={version} has empty '{phase}' "
+                    f"coverage array — claim at least one test"
+                )
+
+    for manifest_version in manifest:
+        if manifest_version not in registry_versions:
+            failures.append(f"stale:{manifest_version}")
+            lines.append(
+                f"  manifest entry target_version={manifest_version} does not "
+                f"match any registered migration — remove or reconcile"
+            )
+
+    if not failures:
+        return [], ""
+
+    message = (
+        "Migration test coverage check failed:\n"
+        + "\n".join(lines)
+        + "\nRegistry is the authoritative set — update the manifest so every "
+        "registered migration claims non-empty blank_db and prior_version "
+        "coverage, and no manifest entry refers to an unregistered version."
+    )
+    return failures, message
+
+
+class TestMigrationTestCoverage:
+    """Happy path: every registered migration has non-empty coverage claims."""
+
+    def test_every_migration_has_blank_and_prior_coverage(self) -> None:
+        failures, message = check_migration_test_coverage(
+            MIGRATIONS, MIGRATION_TEST_COVERAGE
+        )
+        assert not failures, message
+
+
+class TestMigrationTestCoverageRedPath:
+    """Adversarial tests — prove the gate fires for each failure mode.
+
+    Required by ``mp-adversarial-proof-required``.
+    """
+
+    def test_detects_untested_migration(self) -> None:
+        """Fabricated-regression: append a migration with no manifest entry.
+        Gate must name the missing target_version."""
+        new_migration = Migration(target_version=99, apply=lambda c: None)
+        drifted_registry = MIGRATIONS + (new_migration,)
+
+        failures, message = check_migration_test_coverage(
+            drifted_registry, MIGRATION_TEST_COVERAGE
+        )
+
+        assert "missing:99" in failures, (
+            f"gate failed to detect untested migration — got: {failures}"
+        )
+        assert "target_version=99" in message, (
+            f"gate message must name the missing target_version, got: {message!r}"
+        )
+
+    def test_detects_partial_test_coverage(self) -> None:
+        """Fabricated-regression: blank_db populated but prior_version empty.
+        Gate must name the migration AND the missing phase."""
+        partial_manifest: Mapping[int, Mapping[str, Tuple[str, ...]]] = {
+            **MIGRATION_TEST_COVERAGE,
+            2: {
+                "blank_db": ("tests.some_test::test_blank",),
+                "prior_version": (),  # missing
+            },
+        }
+
+        failures, message = check_migration_test_coverage(
+            MIGRATIONS, partial_manifest
+        )
+
+        assert "empty:2:prior_version" in failures, (
+            f"gate failed to detect partial coverage — got: {failures}"
+        )
+        assert "target_version=2" in message, (
+            f"gate message must name the migration, got: {message!r}"
+        )
+        assert "prior_version" in message, (
+            f"gate message must name the missing phase, got: {message!r}"
+        )
+
+    def test_detects_stale_manifest_entry(self) -> None:
+        """Fabricated-regression: manifest entry for an unregistered version
+        (tombstoned migration whose manifest entry was forgotten). Gate
+        must flag it so the manifest stays clean."""
+        stale_manifest: Mapping[int, Mapping[str, Tuple[str, ...]]] = {
+            **MIGRATION_TEST_COVERAGE,
+            999: {
+                "blank_db": ("tests.stale::test",),
+                "prior_version": ("tests.stale::test",),
+            },
+        }
+
+        failures, message = check_migration_test_coverage(
+            MIGRATIONS, stale_manifest
+        )
+
+        assert "stale:999" in failures, (
+            f"gate failed to detect stale manifest entry — got: {failures}"
+        )
+        assert "target_version=999" in message, (
+            f"gate message must name the stale version, got: {message!r}"
+        )

--- a/templates/patterns/p-migration-test-coverage/typescript/README.md
+++ b/templates/patterns/p-migration-test-coverage/typescript/README.md
@@ -1,0 +1,42 @@
+# `p-migration-test-coverage` — TypeScript adaptation
+
+Concept-only. The coverage-claim manifest is declarative JSON/TS, so the port is straightforward — but the test-id format varies by framework (Vitest, Jest, node:test) and the "prior version" semantics depend on how your migration runner exposes upgrade-from-specific-version.
+
+## The registry is still the authoritative manifest
+
+Same core discipline as the Python reference:
+
+- **DO** iterate your migration registry as the source of truth.
+- **DO NOT** file-scan `drizzle/`, `prisma/migrations/`, or `migrations/` directories. Runtime behavior depends on what the registry binds, not what happens to be on disk.
+
+## Apply the same three-checks-per-migration rule
+
+```ts
+for (const migration of MIGRATIONS) {
+  const entry = MIGRATION_TEST_COVERAGE[migration.targetVersion];
+  // 1. entry exists
+  // 2. entry.blankDb.length > 0
+  // 3. entry.priorVersion.length > 0
+}
+// 4. no manifest entry references a targetVersion not in MIGRATIONS
+```
+
+## Ecosystem pointers
+
+### Vitest / Jest
+
+Test ids are typically `<file path>::<describe>::<it>` — the shape your manifest commits to. Add a second verifier that resolves every claimed id against `vitest list` / `jest --listTests` output to upgrade "diffable" to "exact-match verified."
+
+### Drizzle
+
+Drizzle migrations are timestamped SQL files with no explicit registry. The coverage manifest instead keys on `idx` from `drizzle/meta/_journal.json` — those indices are the registry surface your app actually applies.
+
+### Prisma
+
+Prisma migrations live in `prisma/migrations/<timestamp>_<name>/`. The coverage manifest keys on migration directory name. Apply the same "claim both blank and prior-version tests" rule.
+
+## Optional exact-match verifier
+
+The strongest form of this pattern ([`mp-committed-proof-artifacts`](../../../../docs/patterns/meta-principles.md#mp-committed-proof-artifacts)) walks the manifest AND the real test suite and asserts every claimed id resolves to an actual test. Stale claims fail the gate just like missing claims. Worth shipping once the base pattern is stable.
+
+See the [Python reference](../python/) for the canonical shape.

--- a/templates/patterns/p-required-tables-runtime-check/README.md
+++ b/templates/patterns/p-required-tables-runtime-check/README.md
@@ -1,0 +1,69 @@
+# `p-required-tables-runtime-check`
+
+Two-phase table-presence validation at `DatabaseManager.connect()` time. Before migrations run, validate that every "fundamental" table (present since schema inception) exists — reject the file otherwise. After migrations run, validate that every "required" table exists — reject the connection if any migration silently failed to create a later-added table.
+
+_Adapted from `oddessentials/ado-git-repo-insights@9d2d2087`._
+
+## Defect class prevented
+
+Two distinct defects the two phases catch independently:
+
+- **Foreign or corrupted DB file.** The code is handed a `.db` path that isn't actually this project's database — a leftover from another tool, a partial restore, a file with the right extension but different content. Running migrations against it would mutate the file before surfacing any error. The pre-migration phase rejects the connection with a clear message before any DDL is executed.
+- **Silent migration failure.** A migration ran, committed its `PRAGMA user_version` bump, but failed to create the table it claims to create — a bug in the migration body, an unhandled error in a nested `ALTER TABLE`, a timing issue. The post-migration phase catches this at the next code path that depends on the table, rather than letting the defect reach production read paths.
+
+Paired with [`p-schema-migration-parity`](../p-schema-migration-parity/) at the PR-CI surface:
+
+- The parity test catches "added a `CREATE TABLE` to `SCHEMA_SQL` without a migration" on the introducing commit.
+- This runtime check catches the same defect at connect time if the PR gate was bypassed, the harness silently disabled the parity test, or the defect was introduced by a manual DB edit rather than a code change.
+
+See [`mp-defense-in-depth`](../../../docs/patterns/meta-principles.md#mp-defense-in-depth) for the general principle.
+
+## How the pattern works
+
+In `connect()`, distinguish new DB vs existing DB:
+
+- **New DB.** Bootstrap from `SCHEMA_SQL` — schema is declared, no validation needed.
+- **Existing DB (the interesting case).**
+  1. **Phase 1 — fundamental validation.** Assert every table in `FUNDAMENTAL_TABLES` exists. This is the set of tables that have been part of this project's schema since v1. Missing fundamental tables means the file isn't ours — raise a clear error, do NOT run migrations.
+  2. **Migration application.** Apply any pending migrations through the registered chain. `PRAGMA user_version` drives which migrations run.
+  3. **Phase 2 — required validation.** Assert every table in `REQUIRED_TABLES` exists. This is the full set the running app expects after the migration chain completes. Missing required tables means a migration silently failed — raise.
+
+Order is load-bearing:
+
+- Phase 1 before migrations — so a foreign file fails fast without being mutated.
+- Phase 2 after migrations — so a legacy file that legitimately migrates a later-added table in from an earlier version doesn't fail phase 2 prematurely.
+
+Neither phase runs on a brand-new DB that's bootstrapping from `SCHEMA_SQL`. The shape is identical to the bootstrap source, so re-validating it is noise.
+
+## Integration
+
+| Hook                            | Shape                                     | Purpose                                   |
+| ------------------------------- | ----------------------------------------- | ----------------------------------------- |
+| `FUNDAMENTAL_TABLES` constant   | `frozenset[str]`                          | Phase-1 gate (pre-migration)              |
+| `REQUIRED_TABLES` constant      | `frozenset[str]` (⊇ `FUNDAMENTAL_TABLES`) | Phase-2 gate (post-migration)             |
+| `DatabaseManager.connect()`     | hosts both validations                    | The runtime surface where the check fires |
+| `DatabaseError` (or equivalent) | raised on validation failure              | Signals the defect to callers             |
+
+The constants MUST be declared in a single module — shared with the parity test in [`p-schema-migration-parity`](../p-schema-migration-parity/). Having two copies is the exact drift surface the paired-pattern design exists to reduce.
+
+## Failure semantics
+
+Fail loud, not silent:
+
+- Raise a typed exception (`DatabaseError` or similar) with a message that names the missing table(s) and which phase failed.
+- Close the connection before raising so callers don't leak a half-initialized handle.
+- Do not attempt recovery, auto-creation, or fallback — the point of the check is to surface the defect, not paper over it.
+
+## Stack coverage
+
+- **Python (runnable reference):** [`python/`](./python/) — full `DatabaseManager` with two-phase validation, typed `DatabaseError`, happy-path tests for both fresh DB and legacy-DB upgrade paths, adversarial tests for both phase failures.
+- **TypeScript (concept-only):** [`typescript/`](./typescript/) — pointers for wiring the same check into the DB client lifecycle.
+
+## Adversarial tests included
+
+1. `test_fails_when_fundamental_missing_pre_migration` (fabricated-regression) — creates a DB with a fundamental table missing, connects, asserts the raised error names the missing table and references phase 1. Proves migrations are NOT run against foreign files.
+2. `test_fails_when_required_missing_post_migration` (fabricated-regression) — simulates a silently-broken migration by pre-populating the DB with the fundamental tables but omitting a later-required table, then connects without the migration present. Asserts the raised error names the missing table and references phase 2.
+
+## Design principles this template obeys
+
+This pattern follows: `mp-adversarial-proof-required`, `mp-defense-in-depth` — see [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.

--- a/templates/patterns/p-required-tables-runtime-check/python/__init__.py
+++ b/templates/patterns/p-required-tables-runtime-check/python/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable reference for the p-required-tables-runtime-check pattern."""

--- a/templates/patterns/p-required-tables-runtime-check/python/reference_database.py
+++ b/templates/patterns/p-required-tables-runtime-check/python/reference_database.py
@@ -1,0 +1,109 @@
+"""Reference DatabaseManager with two-phase runtime table-presence check.
+
+The connect() method distinguishes new-DB bootstrap from existing-DB
+upgrade and runs FUNDAMENTAL_TABLES validation pre-migration,
+REQUIRED_TABLES validation post-migration.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from .reference_migrations import MIGRATIONS
+from .reference_schema import SCHEMA_SQL
+
+
+FUNDAMENTAL_TABLES: frozenset[str] = frozenset({"users"})
+"""Tables present since v1. Missing fundamental tables in an existing DB file
+means the file isn't ours — raise before running any migration."""
+
+REQUIRED_TABLES: frozenset[str] = frozenset({"users", "sessions", "audit_log"})
+"""Tables the running app expects after all migrations have applied. Missing
+required tables post-migration means a migration silently failed — raise."""
+
+
+class DatabaseError(Exception):
+    """Raised when the runtime table-presence check fails."""
+
+
+class DatabaseManager:
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self._connection: sqlite3.Connection | None = None
+
+    @property
+    def connection(self) -> sqlite3.Connection:
+        if self._connection is None:
+            raise DatabaseError("not connected — call connect() first")
+        return self._connection
+
+    def connect(self) -> None:
+        is_new_db = not self.db_path.exists()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._connection = sqlite3.connect(str(self.db_path))
+            self._connection.row_factory = sqlite3.Row
+            self._connection.execute("PRAGMA foreign_keys = ON")
+
+            if is_new_db:
+                # New DB: bootstrap from SCHEMA_SQL. Re-validating against the
+                # bootstrap source is noise.
+                self._connection.executescript(SCHEMA_SQL)
+                return
+
+            # Existing DB: two-phase validation around the migration chain.
+            #
+            #   Phase 1 (pre-migration, fundamental-only): reject foreign or
+            #   catastrophically-damaged files BEFORE running migrations. A
+            #   missing fundamental table means the file isn't ours;
+            #   migrations against it would mutate a bad file.
+            #
+            #   Phase 2 (post-migration, full required set): catch silent
+            #   migration failures. Order matters — we can't require the
+            #   full set pre-migration because legacy files are allowed to
+            #   be missing later-added tables until migrations supply them.
+            self._validate_tables_present(FUNDAMENTAL_TABLES, phase="pre-migration")
+            self._apply_migrations()
+            self._validate_tables_present(REQUIRED_TABLES, phase="post-migration")
+        except (sqlite3.Error, DatabaseError):
+            self.close()
+            raise
+
+    def close(self) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    def _validate_tables_present(
+        self, required: frozenset[str], *, phase: str
+    ) -> None:
+        cursor = self.connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )
+        present = frozenset(row[0] for row in cursor.fetchall())
+        missing = required - present
+        if missing:
+            raise DatabaseError(
+                f"{phase} table validation failed: missing {sorted(missing)}. "
+                f"Required set for this phase: {sorted(required)}. "
+                f"Expected tables not found — the database file may be "
+                f"foreign, partially migrated, or a migration silently "
+                f"failed to create the required table(s)."
+            )
+
+    @staticmethod
+    def _current_version(conn: sqlite3.Connection) -> int:
+        row = conn.execute("PRAGMA user_version").fetchone()
+        return int(row[0]) if row else 0
+
+    def _apply_migrations(self) -> None:
+        conn = self.connection
+        current = self._current_version(conn)
+        for migration in MIGRATIONS:
+            if migration.target_version <= current:
+                continue
+            migration.apply(conn)
+            conn.execute(f"PRAGMA user_version = {migration.target_version}")
+        conn.commit()

--- a/templates/patterns/p-required-tables-runtime-check/python/reference_migrations.py
+++ b/templates/patterns/p-required-tables-runtime-check/python/reference_migrations.py
@@ -1,0 +1,44 @@
+"""Ordered migration registry."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+
+@dataclass(frozen=True)
+class Migration:
+    target_version: int
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            expires_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+def _migrate_v2_to_v3(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id INTEGER PRIMARY KEY,
+            actor_id INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            occurred_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+MIGRATIONS: Tuple[Migration, ...] = (
+    Migration(target_version=2, apply=_migrate_v1_to_v2),
+    Migration(target_version=3, apply=_migrate_v2_to_v3),
+)

--- a/templates/patterns/p-required-tables-runtime-check/python/reference_schema.py
+++ b/templates/patterns/p-required-tables-runtime-check/python/reference_schema.py
@@ -1,0 +1,32 @@
+"""Canonical schema source for the reference."""
+
+from __future__ import annotations
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    expires_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY,
+    actor_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    occurred_at TEXT NOT NULL
+);
+"""
+
+V1_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+"""

--- a/templates/patterns/p-required-tables-runtime-check/python/test_required_tables_runtime_check.py
+++ b/templates/patterns/p-required-tables-runtime-check/python/test_required_tables_runtime_check.py
@@ -1,0 +1,177 @@
+"""Runtime two-phase table-presence check around the migration chain.
+
+Defect class prevented
+----------------------
+Two distinct defects the phases catch independently:
+
+- **Foreign DB file.** Code hands a ``.db`` path that isn't this project's
+  database. Phase 1 rejects before any migration mutates the file.
+- **Silently broken migration.** A migration bumps ``user_version`` but
+  fails to create the table it claims to create. Phase 2 catches it
+  before read paths in production reference the missing table.
+
+Pairs with ``p-schema-migration-parity`` at the PR-CI surface
+(see ``mp-defense-in-depth``).
+
+Adaptation
+----------
+Copy this file into your test suite. Required hooks:
+
+- ``FUNDAMENTAL_TABLES: frozenset[str]`` — phase-1 gate
+- ``REQUIRED_TABLES: frozenset[str]`` — phase-2 gate (⊇ fundamental)
+- ``DatabaseManager.connect()`` — hosts both validations
+- ``DatabaseError`` (or equivalent) — raised on validation failure
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from .reference_database import (
+    DatabaseError,
+    DatabaseManager,
+    FUNDAMENTAL_TABLES,
+    REQUIRED_TABLES,
+)
+from .reference_schema import V1_SCHEMA_SQL
+
+
+class TestRuntimeCheckHappyPath:
+    """Both fresh DB and legacy-DB-upgrade paths connect without error."""
+
+    def test_fresh_database_bootstraps_without_validation(
+        self, tmp_path: Path
+    ) -> None:
+        """Fresh DBs re-validating against their own bootstrap source is
+        noise — ensure the check is skipped on is_new_db.
+        """
+        manager = DatabaseManager(tmp_path / "fresh.db")
+        manager.connect()
+        try:
+            present = _present_tables(manager.connection)
+            assert REQUIRED_TABLES <= present, (
+                f"fresh DB should have all required tables after bootstrap, "
+                f"missing: {sorted(REQUIRED_TABLES - present)}"
+            )
+        finally:
+            manager.close()
+
+    def test_legacy_v1_db_upgrades_and_passes_both_phases(
+        self, tmp_path: Path
+    ) -> None:
+        """A v1-seeded file should pass phase 1 (fundamental present),
+        run migrations, and pass phase 2 (required present)."""
+        db_path = tmp_path / "legacy.db"
+        seed = sqlite3.connect(str(db_path))
+        try:
+            seed.executescript(V1_SCHEMA_SQL)
+        finally:
+            seed.close()
+
+        manager = DatabaseManager(db_path)
+        manager.connect()
+        try:
+            present = _present_tables(manager.connection)
+            assert REQUIRED_TABLES <= present, (
+                f"legacy DB should have all required tables post-migration, "
+                f"missing: {sorted(REQUIRED_TABLES - present)}"
+            )
+        finally:
+            manager.close()
+
+
+class TestRuntimeCheckRedPath:
+    """Adversarial tests — prove each phase fires on the regression case."""
+
+    def test_fails_when_fundamental_missing_pre_migration(
+        self, tmp_path: Path
+    ) -> None:
+        """Fabricated-regression: hand the manager a DB file that is missing
+        a fundamental table. Phase 1 must reject before migrations run.
+        """
+        foreign_db = tmp_path / "foreign.db"
+        conn = sqlite3.connect(str(foreign_db))
+        try:
+            # A file that exists but lacks the fundamental `users` table.
+            # Populated with an arbitrary unrelated table so it's non-empty.
+            conn.executescript("CREATE TABLE unrelated (x INTEGER);")
+        finally:
+            conn.close()
+
+        manager = DatabaseManager(foreign_db)
+        with pytest.raises(DatabaseError) as excinfo:
+            manager.connect()
+
+        message = str(excinfo.value)
+        assert "pre-migration" in message, (
+            f"error must name the phase that failed, got: {message!r}"
+        )
+        assert "users" in message, (
+            f"error must name the missing fundamental table, got: {message!r}"
+        )
+        # Confirm migrations did NOT run — `user_version` should still be 0.
+        check = sqlite3.connect(str(foreign_db))
+        try:
+            row = check.execute("PRAGMA user_version").fetchone()
+            assert row[0] == 0, (
+                f"phase-1 failure must reject BEFORE migrations run, but "
+                f"user_version={row[0]} indicates a migration ran"
+            )
+        finally:
+            check.close()
+
+    def test_fails_when_required_missing_post_migration(
+        self, tmp_path: Path
+    ) -> None:
+        """Fabricated-regression: construct a legacy DB with fundamental
+        tables present and ``user_version`` already at the latest so the
+        migration chain skips application, but a later-added required
+        table is missing. Phase 2 must detect this and raise.
+
+        This simulates a migration that bumped ``user_version`` but
+        silently failed to create its required table — exactly the
+        regression the post-migration phase exists to catch.
+        """
+        latest_target = max(m.target_version for m in _migrations())
+        stale_db = tmp_path / "stale.db"
+        conn = sqlite3.connect(str(stale_db))
+        try:
+            conn.executescript(V1_SCHEMA_SQL)
+            # Pretend migrations up through the latest ran — but sessions /
+            # audit_log were silently NOT created.
+            conn.execute(f"PRAGMA user_version = {latest_target}")
+            conn.commit()
+        finally:
+            conn.close()
+
+        manager = DatabaseManager(stale_db)
+        with pytest.raises(DatabaseError) as excinfo:
+            manager.connect()
+
+        message = str(excinfo.value)
+        assert "post-migration" in message, (
+            f"error must name the phase that failed, got: {message!r}"
+        )
+        missing_set = REQUIRED_TABLES - FUNDAMENTAL_TABLES
+        missing_named = [t for t in missing_set if t in message]
+        assert missing_named, (
+            f"error must name at least one missing post-migration table "
+            f"(expected one of {sorted(missing_set)}), got: {message!r}"
+        )
+
+
+def _migrations():
+    """Import here to avoid leaking private names at module scope."""
+    from .reference_migrations import MIGRATIONS
+
+    return MIGRATIONS
+
+
+def _present_tables(conn: sqlite3.Connection) -> frozenset[str]:
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )
+    return frozenset(row[0] for row in cursor.fetchall())

--- a/templates/patterns/p-required-tables-runtime-check/typescript/README.md
+++ b/templates/patterns/p-required-tables-runtime-check/typescript/README.md
@@ -1,0 +1,54 @@
+# `p-required-tables-runtime-check` — TypeScript adaptation
+
+Concept-only. The lifecycle hook (where you intercept DB connect) varies by client library — a generic TS skeleton would assume a shape that doesn't match most real projects.
+
+## Where to wire the check
+
+The check goes in the code path that opens a database handle. Two phases, ordered:
+
+```ts
+async function connectDatabase(path: string): Promise<Database> {
+  const isNewDb = !(await fileExists(path));
+  const db = await openConnection(path);
+
+  if (isNewDb) {
+    await bootstrapFromSchemaSql(db);
+    return db;
+  }
+
+  await validateTablesPresent(db, FUNDAMENTAL_TABLES, "pre-migration");
+  await runMigrations(db);
+  await validateTablesPresent(db, REQUIRED_TABLES, "post-migration");
+  return db;
+}
+```
+
+Ordering is load-bearing: phase 1 before migrations so foreign files aren't mutated; phase 2 after migrations so legacy files get a chance to migrate later-added tables in.
+
+## Ecosystem pointers
+
+### SQLite via `better-sqlite3`
+
+Introspect presence via `SELECT name FROM sqlite_master WHERE type='table'`. Close the connection on error before throwing so callers don't get a half-initialized handle.
+
+### Postgres via `pg` / `postgres.js`
+
+Introspect via `information_schema.tables` filtered to the target schema. The same two-phase structure applies — run your migration runner between the two checks.
+
+### Knex / TypeORM / Drizzle
+
+Most ORMs expose a raw connection for introspection (`knex.raw`, `dataSource.query`, `db.run`). Prefer the raw path for the check — going through the ORM's query builder adds drift surface (the builder might transform table names, apply schema prefixes, etc.) that defeats the "is this file really ours" test.
+
+## Failure semantics
+
+Fail loud:
+
+- Throw a typed error (`DatabaseError`, `ValidationError`) with a message that names the missing tables and which phase failed.
+- Close the connection before throwing so callers don't leak a half-initialized handle.
+- Do not attempt recovery or auto-creation — the point is to surface the defect.
+
+## Pairing with shift-left
+
+See [`p-schema-migration-parity`](../../p-schema-migration-parity/typescript/) for the PR-CI-surface companion. The pair covers the same defect class at both the introducing-commit surface and the connect-time surface — see [`mp-defense-in-depth`](../../../../docs/patterns/meta-principles.md#mp-defense-in-depth).
+
+See the [Python reference](../python/) for the canonical shape.

--- a/templates/patterns/p-schema-migration-parity/README.md
+++ b/templates/patterns/p-schema-migration-parity/README.md
@@ -1,0 +1,71 @@
+# `p-schema-migration-parity`
+
+Static test asserting every table declared in the canonical schema source is either in a "fundamental" set (present since inception) or created by at least one registered migration. Shifts detection of "added table to schema, forgot the migration" from production runtime to PR CI.
+
+_Adapted from `oddessentials/ado-git-repo-insights@9d2d2087`._
+
+## Defect class prevented
+
+A `CREATE TABLE` added to the canonical schema source without a paired migration ships silently:
+
+- Fresh databases receive the new table because they bootstrap from the canonical schema.
+- Legacy databases upgrade through the migration chain, which never mentions the table, and reach the running app missing it.
+- The first write path that references the table raises `OperationalError: no such table` in production.
+
+This defect is invisible to every CI leg that only tests against fresh DBs. The parity test is the PR-time gate that forces the invariant into view on the introducing commit.
+
+## How the pattern works
+
+Two enumerations, one subtraction:
+
+1. **Schema tables.** Materialize the canonical `SCHEMA_SQL` in an in-memory SQLite DB and read `sqlite_master` for the real declared set. (Real materialization is more robust than regex/AST scanning — it captures whatever SQLite actually creates regardless of statement form.)
+2. **Migration-chain tables.** Seed a temp DB with the oldest-supported `v1` schema, connect through the production `DatabaseManager` so the real upgrade path runs, and read `sqlite_master` again.
+3. **Invariant.** `schema_tables ⊆ FUNDAMENTAL_TABLES ∪ migration_chain_tables`. Any difference is a table declared in schema but unreachable through the migration path — fail with a message that names the offending tables and both remediation paths (add a migration, or extend the fundamental set).
+
+The test runs at `ci-pr` execution stage. Pair with [`p-required-tables-runtime-check`](../p-required-tables-runtime-check/) for runtime defense-in-depth — the shift-left gate catches the defect on the introducing PR; the runtime gate catches it on legacy-DB connect if the PR gate was somehow bypassed.
+
+## Integration
+
+Three hooks the test assumes exist in your persistence layer:
+
+| Hook                          | Shape                              | Purpose                                                     |
+| ----------------------------- | ---------------------------------- | ----------------------------------------------------------- |
+| `SCHEMA_SQL` constant         | `str` of `CREATE TABLE` statements | Canonical declared schema                                   |
+| `FUNDAMENTAL_TABLES` constant | `frozenset[str]`                   | Tables present since v1 (exempt from requiring a migration) |
+| `DatabaseManager.connect()`   | runs the migration chain           | Exercised by the test to compute chain-created tables       |
+
+The reference under [`python/`](./python/) shows one valid shape. Copy `test_schema_migration_parity.py` into your test suite and replace the `from . import reference_*` lines with imports against your own persistence module.
+
+The test is read-only on the real schema — the red-path test appends a canary DDL to a _copy_ of `SCHEMA_SQL`, never to the module constant.
+
+## Scope discipline
+
+**This test locks table-name presence only.** It must NOT be extended to lock:
+
+- column shapes, counts, or types,
+- index presence or ordering,
+- constraint bodies,
+- row-count or seed-data assertions,
+- any prose in surrounding schema documentation.
+
+Use [`p-migration-ddl-parity`](../p-migration-ddl-parity/) for structural byte-equivalence between the canonical schema and the migration chain. Conflating the two surfaces turns this test into churn bait — the next column-rename PR will trip it for unrelated reasons, consumers will learn to bypass it, and the original defect class (missing table) stops being protected.
+
+If you need a broader lock, ship it as a separate test with its own name so reviewers can see which invariant is firing. Do not widen this one.
+
+## Stack coverage
+
+- **Python (runnable reference):** [`python/`](./python/) — full SQLite reference using `pytest`'s `tmp_path` fixture, includes both the happy-path test and the red-path (adversarial) tests.
+- **TypeScript (concept-only):** [`typescript/`](./typescript/) — pointers to drizzle-kit / Kysely / node-pg-migrate for the equivalent pattern shape. No runnable skeleton: the parity test is tightly coupled to the migration registry shape, and a generic TS skeleton would either be wrong for most registries or too abstract to adapt faithfully.
+
+## Adversarial tests included
+
+Per [`mp-adversarial-proof-required`](../../../docs/patterns/meta-principles.md#mp-adversarial-proof-required), the reference test file ships two adversarial tests alongside the happy-path test:
+
+1. `test_detects_missing_migration` (fabricated-regression) — appends a canary `CREATE TABLE` to a copy of `SCHEMA_SQL` and asserts the gate names the canary explicitly in its failure message, including both remediation paths.
+2. `test_detects_missing_migration_when_chain_empty` (removed-correctness) — simulates a broken migration runner by computing the unmigrated set against an empty chain, and asserts every non-fundamental schema table is flagged. If the migration-chain arm of the allowed set silently became a no-op, this test would catch it.
+
+Both tests reference the happy-path check by name so the linkage is obvious in the file.
+
+## Design principles this template obeys
+
+This pattern follows: `mp-adversarial-proof-required`, `mp-churn-bait-discipline`, `mp-point-in-time-structural-claims` — see [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.

--- a/templates/patterns/p-schema-migration-parity/python/__init__.py
+++ b/templates/patterns/p-schema-migration-parity/python/__init__.py
@@ -1,0 +1,14 @@
+"""Runnable reference for the p-schema-migration-parity pattern.
+
+The four modules here demonstrate one valid shape for the three hooks the
+parity test assumes:
+
+- ``reference_schema.SCHEMA_SQL`` — canonical declared schema
+- ``reference_database.FUNDAMENTAL_TABLES`` — tables present since v1
+- ``reference_database.DatabaseManager`` — runs the registered migration chain
+- ``reference_migrations.MIGRATIONS`` — ordered registry of migrations
+
+Consumers typically do not copy this whole package; they copy
+``test_schema_migration_parity.py`` and re-point the imports at their own
+persistence module.
+"""

--- a/templates/patterns/p-schema-migration-parity/python/reference_database.py
+++ b/templates/patterns/p-schema-migration-parity/python/reference_database.py
@@ -1,0 +1,62 @@
+"""Reference DatabaseManager — runs the migration chain on connect.
+
+Minimal shape the parity test relies on. Your project's equivalent can be
+richer (connection pooling, retry, telemetry, etc.) as long as
+``connect()`` drives the registered migration chain to completion before
+returning.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from .reference_migrations import MIGRATIONS
+
+FUNDAMENTAL_TABLES: frozenset[str] = frozenset({"users"})
+"""Tables that have always existed (since v1). Any schema-declared table NOT
+in this set must be created by at least one registered migration — the
+invariant the parity test enforces.
+
+Add a table here only when it has been present since the project's earliest
+supported schema version. For any table introduced after v1, the correct
+remediation is a migration, not an extension of this set."""
+
+REQUIRED_TABLES: frozenset[str] = frozenset({"users", "sessions", "audit_log"})
+"""Tables the running app expects after the full migration chain completes.
+Used by ``p-required-tables-runtime-check`` at connect time; redundant with
+the parity test at the PR surface (that's the defense-in-depth design —
+see mp-defense-in-depth)."""
+
+
+class DatabaseManager:
+    """Minimal manager — open, run migrations, expose connection."""
+
+    def __init__(self, db_path: Path) -> None:
+        self.db_path = db_path
+        self.connection: sqlite3.Connection | None = None
+
+    def connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path))
+        self._apply_migrations(conn)
+        self.connection = conn
+        return conn
+
+    def close(self) -> None:
+        if self.connection is not None:
+            self.connection.close()
+            self.connection = None
+
+    @staticmethod
+    def _current_version(conn: sqlite3.Connection) -> int:
+        row = conn.execute("PRAGMA user_version").fetchone()
+        return int(row[0]) if row else 0
+
+    def _apply_migrations(self, conn: sqlite3.Connection) -> None:
+        current = self._current_version(conn)
+        for migration in MIGRATIONS:
+            if migration.target_version <= current:
+                continue
+            migration.apply(conn)
+            conn.execute(f"PRAGMA user_version = {migration.target_version}")
+        conn.commit()

--- a/templates/patterns/p-schema-migration-parity/python/reference_migrations.py
+++ b/templates/patterns/p-schema-migration-parity/python/reference_migrations.py
@@ -1,0 +1,55 @@
+"""Ordered migration registry.
+
+Each :class:`Migration` carries ``target_version`` — the schema_version it
+upgrades the DB to — and ``apply(connection)`` which performs the DDL. The
+parity test does not call these directly; it drives the migration chain
+through :class:`DatabaseManager` so the real production upgrade path is
+exercised (ordering, pre-validation, post-validation).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+
+@dataclass(frozen=True)
+class Migration:
+    target_version: int
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            expires_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+def _migrate_v2_to_v3(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id INTEGER PRIMARY KEY,
+            actor_id INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            occurred_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+MIGRATIONS: Tuple[Migration, ...] = (
+    Migration(target_version=2, apply=_migrate_v1_to_v2),
+    Migration(target_version=3, apply=_migrate_v2_to_v3),
+)
+"""The authoritative migration registry. The migration-test-coverage pattern
+walks this tuple to verify every entry has a corresponding test; the
+schema-version-monotonic pattern compares ``max(target_version)`` here
+against ``SCHEMA_VERSION_SEED`` in :mod:`reference_schema`."""

--- a/templates/patterns/p-schema-migration-parity/python/reference_schema.py
+++ b/templates/patterns/p-schema-migration-parity/python/reference_schema.py
@@ -1,0 +1,46 @@
+"""Canonical schema source — the declared shape the running app expects.
+
+Replace this module with your project's schema source. The parity test reads
+``SCHEMA_SQL`` from here, materializes it in memory, and reads back the real
+table set from ``sqlite_master``.
+"""
+
+from __future__ import annotations
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    expires_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY,
+    actor_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    occurred_at TEXT NOT NULL
+);
+"""
+
+SCHEMA_VERSION_SEED = 3
+"""Schema version seed — MUST equal max(target_version) across the migration
+registry. Enforced by p-schema-version-monotonic."""
+
+V1_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+"""
+"""Oldest-supported seed. The parity test seeds a temp DB with this script
+before running the migration chain so the test exercises the real legacy
+upgrade path. If your project supports an older starting point, keep this
+constant as the single source of truth and import it everywhere it's used —
+never copy."""

--- a/templates/patterns/p-schema-migration-parity/python/test_schema_migration_parity.py
+++ b/templates/patterns/p-schema-migration-parity/python/test_schema_migration_parity.py
@@ -1,0 +1,198 @@
+"""Static parity: every SCHEMA_SQL table is fundamental or migration-created.
+
+Defect class prevented
+----------------------
+A ``CREATE TABLE`` added to the canonical schema source without a paired
+migration ships silently. Fresh databases receive the table (bootstrapped
+from ``SCHEMA_SQL``) but legacy databases upgrade through the migration
+chain that never mentions it and reach the running app missing it. First
+production write hits ``sqlite3.OperationalError: no such table``.
+
+This test runs at PR-CI time on the introducing commit and fails with a
+message that names the offending tables and both remediation paths.
+
+Scope discipline
+----------------
+This test locks **table-name presence only**. It must NOT be extended to
+column shapes, index presence, constraint bodies, or any prose in the
+surrounding schema doc. Use ``p-migration-ddl-parity`` for byte-level
+structural equivalence. Widening the lock surface here turns the test into
+churn bait — consumers bypass it on the first unrelated column-rename PR
+and the original defect class stops being protected.
+
+(See ``mp-churn-bait-discipline``.)
+
+Adaptation
+----------
+Copy this file into your test suite and adjust the imports to point at
+your project's persistence layer. The test requires three hooks:
+
+- ``SCHEMA_SQL: str`` — canonical declared schema
+- ``FUNDAMENTAL_TABLES: frozenset[str]`` — tables present since v1
+- ``DatabaseManager.connect()`` — runs the registered migration chain
+
+The ``V1_SCHEMA_SQL`` constant is the oldest-supported seed; keep it as a
+single source of truth in your persistence module and import it here,
+never copy.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Tuple
+
+from . import reference_schema
+from .reference_database import FUNDAMENTAL_TABLES, DatabaseManager
+
+
+def _user_table_names(conn: sqlite3.Connection) -> frozenset[str]:
+    """Table names excluding SQLite internals (``sqlite_sequence`` etc.)."""
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master "
+        "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+    )
+    return frozenset(row[0] for row in cursor.fetchall())
+
+
+def _enumerate_schema_sql_tables(schema_sql: str) -> frozenset[str]:
+    """Materialize ``schema_sql`` in memory and read the real declared set.
+
+    Real materialization is materially more robust than regex/AST scanning
+    of the DDL — it captures whatever tables SQLite actually creates,
+    regardless of statement form (``CREATE TABLE`` vs ``CREATE TABLE IF
+    NOT EXISTS`` vs multi-statement scripts).
+    """
+    conn = sqlite3.connect(":memory:")
+    try:
+        conn.executescript(schema_sql)
+        return _user_table_names(conn)
+    finally:
+        conn.close()
+
+
+def _enumerate_migration_chain_tables(tmp_path: Path) -> frozenset[str]:
+    """Tables present after running the full chain on the v1 seed.
+
+    Goes through :class:`DatabaseManager` rather than calling each
+    ``_migrate_vN_to_vN+1`` directly so the test exercises the real upgrade
+    path legacy databases hit — including ordering and any pre/post
+    validation the manager performs.
+    """
+    db_path = tmp_path / "migration-chain.db"
+    seed = sqlite3.connect(str(db_path))
+    try:
+        seed.executescript(reference_schema.V1_SCHEMA_SQL)
+    finally:
+        seed.close()
+    manager = DatabaseManager(db_path)
+    manager.connect()
+    try:
+        assert manager.connection is not None
+        return _user_table_names(manager.connection)
+    finally:
+        manager.close()
+
+
+def _check_parity(
+    schema_sql: str, tmp_path: Path
+) -> Tuple[frozenset[str], str]:
+    """Return ``(unmigrated_tables, formatted_message)``.
+
+    Single source of truth for the failure wording so happy-path and
+    red-path tests cannot drift. When ``unmigrated_tables`` is empty,
+    parity holds.
+    """
+    schema_tables = _enumerate_schema_sql_tables(schema_sql)
+    chain_tables = _enumerate_migration_chain_tables(tmp_path)
+    allowed = FUNDAMENTAL_TABLES | chain_tables
+    unmigrated = schema_tables - allowed
+    message = (
+        f"Tables declared in SCHEMA_SQL but neither in FUNDAMENTAL_TABLES "
+        f"nor created by any registered migration: {sorted(unmigrated)}. "
+        "Remediation: add a migration that creates each missing table, or "
+        "extend FUNDAMENTAL_TABLES if the table has been part of this "
+        "project's schema since v1."
+    )
+    return unmigrated, message
+
+
+class TestSchemaMigrationParity:
+    """Happy path: healthy schema passes."""
+
+    def test_schema_sql_tables_are_fundamental_or_migration_created(
+        self, tmp_path: Path
+    ) -> None:
+        unmigrated, message = _check_parity(
+            reference_schema.SCHEMA_SQL, tmp_path
+        )
+        assert not unmigrated, message
+
+
+class TestSchemaMigrationParityRedPath:
+    """Adversarial tests — prove the gate fires on the regression case.
+
+    Required by ``mp-adversarial-proof-required``: a gate without a red
+    path is a gate you cannot trust. A broadened assertion, a swallowed
+    exception, or a permissive matcher would let the happy-path test pass
+    while silently failing to enforce anything; these tests close that
+    drift surface.
+    """
+
+    def test_detects_missing_migration(self, tmp_path: Path) -> None:
+        """Fabricated-regression test: append a canary ``CREATE TABLE`` to a
+        _copy_ of ``SCHEMA_SQL`` (never mutating the module constant) and
+        confirm the gate names the canary explicitly in its failure message.
+        """
+        canary_ddl = (
+            "\nCREATE TABLE IF NOT EXISTS unmigrated_canary "
+            "(id INTEGER PRIMARY KEY);\n"
+        )
+        unmigrated, message = _check_parity(
+            reference_schema.SCHEMA_SQL + canary_ddl, tmp_path
+        )
+
+        assert unmigrated == frozenset({"unmigrated_canary"}), (
+            "gate failed to detect the synthetic unmigrated table — expected "
+            f"{{'unmigrated_canary'}}, got {sorted(unmigrated)}"
+        )
+        assert "unmigrated_canary" in message, (
+            f"gate message must name the offending table, got: {message!r}"
+        )
+        assert "migration" in message, (
+            "gate message must mention migration as the primary remediation "
+            f"path, got: {message!r}"
+        )
+        assert "FUNDAMENTAL_TABLES" in message, (
+            "gate message must mention FUNDAMENTAL_TABLES as the secondary "
+            f"remediation path, got: {message!r}"
+        )
+
+    def test_detects_missing_migration_when_chain_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Removed-correctness test: simulate a broken/disabled migration
+        runner by computing the unmigrated set against an empty chain. Every
+        non-fundamental schema table must be flagged. Proves the
+        migration-chain arm of the allowed set is load-bearing — if it
+        silently became a no-op, this test would catch it.
+
+        Fundamental tables remain covered; they're the escape hatch's whole
+        purpose.
+        """
+        schema_tables = _enumerate_schema_sql_tables(reference_schema.SCHEMA_SQL)
+        allowed_without_chain = FUNDAMENTAL_TABLES  # chain contribution removed
+        unmigrated = schema_tables - allowed_without_chain
+
+        assert "sessions" in unmigrated, (
+            "removing the migration-chain arm should flag 'sessions' — "
+            f"got: {sorted(unmigrated)}"
+        )
+        assert "audit_log" in unmigrated, (
+            "removing the migration-chain arm should flag 'audit_log' — "
+            f"got: {sorted(unmigrated)}"
+        )
+        assert "users" not in unmigrated, (
+            "'users' stays covered by FUNDAMENTAL_TABLES even when the chain "
+            f"is removed — that's the escape hatch's purpose; got: {sorted(unmigrated)}"
+        )

--- a/templates/patterns/p-schema-migration-parity/typescript/README.md
+++ b/templates/patterns/p-schema-migration-parity/typescript/README.md
@@ -1,0 +1,31 @@
+# `p-schema-migration-parity` — TypeScript adaptation
+
+Concept-only. The persistence parity patterns are tightly coupled to (a) your canonical schema source, (b) the shape of your migration registry, and (c) the DB access layer's connect-time lifecycle hook. A generic TS skeleton would either be wrong for most registries or too abstract to adapt faithfully — so this template ships pointers instead of code.
+
+## Apply the same three-step check
+
+1. **Enumerate declared tables** — introspect your schema source. For `drizzle-orm`, walk the exported schema object (`Object.values(schema)` filtered to `Table` instances) and read `.name`. For plain SQL, materialize the DDL in an in-memory `better-sqlite3` (for SQLite) or `pg-mem` (for Postgres) and query `sqlite_master` / `information_schema.tables`.
+2. **Enumerate migration-chain tables** — seed a temp DB with your oldest-supported version, run every registered migration through the normal migration runner (drizzle-kit, node-pg-migrate, Kysely migrator), then introspect the resulting DB.
+3. **Assert** `schema_tables ⊆ fundamental_tables ∪ migration_chain_tables` — same invariant as the Python reference.
+
+## Ecosystem pointers
+
+| Tool                                                                                       | Where the hooks live                                                                                                                                        |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`drizzle-kit`](https://orm.drizzle.team/kit-docs/overview)                                | Schema source: `src/db/schema.ts` exports. Migration registry: `drizzle/` directory of generated SQL files + `__drizzle_migrations` journal.                |
+| [`Kysely`](https://kysely.dev/) + [`kysely-ctl`](https://github.com/kysely-org/kysely-ctl) | Schema source: your `Database` interface + one-off `createTable` calls in an init module. Migration registry: `Migrator` with `provideMigrationProvider()`. |
+| [`node-pg-migrate`](https://salsita.github.io/node-pg-migrate/)                            | Schema source: conventional `schema.sql` or generated dump. Migration registry: `migrations/` timestamped JS files.                                         |
+| [`Prisma`](https://www.prisma.io/)                                                         | Schema source: `schema.prisma`. Migration registry: `prisma/migrations/` directory. Introspection via `prisma migrate diff`.                                |
+
+## Practical notes for TS adaptations
+
+- Prefer [`vitest`](https://vitest.dev/)'s `expect.objectContaining`-style assertions over hand-rolled set diffs — the failure message is more readable.
+- If your migration runner is async, remember to await it in the test harness before introspecting the resulting DB.
+- For Postgres projects, use [`pg-mem`](https://github.com/oguimbal/pg-mem) for the in-memory materialization step — it supports enough of the Postgres dialect to cover most schema DDL.
+- Keep the v1 seed as a single exported constant and import it in every test that walks the migration chain. Copying the seed into multiple tests is the exact drift surface this pattern exists to reduce.
+
+## Scope discipline applies identically
+
+The TS version MUST NOT be extended to lock column shapes, constraint bodies, or index presence. Pair with `p-migration-ddl-parity` for structural byte-equivalence if you need that coverage. The churn-bait failure mode is language-agnostic.
+
+See the [Python reference](../python/) for the canonical shape.

--- a/templates/patterns/p-schema-version-monotonic/README.md
+++ b/templates/patterns/p-schema-version-monotonic/README.md
@@ -1,0 +1,71 @@
+# `p-schema-version-monotonic`
+
+CI gate asserting the `schema_version` seed embedded in the canonical schema source equals `max(target_version)` across the registered migration registry. Catches "added a migration, forgot to bump the seed" — where fresh DBs boot at an older schema version than the latest migration targets.
+
+_Adapted from `oddessentials/ado-git-repo-insights@9d2d2087` (conceptual; no direct reference test in source)._
+
+## Defect class prevented
+
+The schema source declares a version seed that fresh databases write into `schema_version` (or `PRAGMA user_version`) on bootstrap. The migration registry advances that version as migrations run. When the two drift:
+
+- Fresh DBs boot at `seed=6`, but the latest registered migration targets `v7`.
+- Fresh DBs bypass the v6→v7 migration because their `user_version` isn't less than 7 after the seed — but the v7 schema hasn't actually been applied.
+- Subsequent code paths that depend on v7-only tables / columns raise against fresh DBs; legacy DBs that went through the chain work fine.
+
+The defect is invisible to any test that only exercises the migration path — migrations run correctly end-to-end; fresh-bootstrap is the broken leg.
+
+Three scenarios the gate catches:
+
+1. **Seed lag.** Seed stayed at `v6` while a `v6→v7` migration landed.
+2. **Seed overshoot.** Seed was bumped to `v8` without a corresponding `v7→v8` migration.
+3. **Empty migration registry with non-zero seed.** Usually a bootstrap bug.
+
+## How the pattern works
+
+Two integer reads, one equality:
+
+1. **Read** `SCHEMA_VERSION_SEED` from the canonical schema module.
+2. **Read** `max(m.target_version for m in MIGRATIONS)` from the registry.
+3. **Assert** they're equal. Fail with a message that names both values and the direction of drift.
+
+When the registry is empty, the seed MUST be 0 (or whatever your project's "no migrations yet" convention is). Empty registry + non-zero seed is ill-defined.
+
+The check runs at `ci-pr` execution stage.
+
+## Integration
+
+Two hooks:
+
+| Hook                           | Shape                                             | Purpose                            |
+| ------------------------------ | ------------------------------------------------- | ---------------------------------- |
+| `SCHEMA_VERSION_SEED` constant | `int`                                             | The version fresh DBs boot at      |
+| `MIGRATIONS` registry          | `Sequence[Migration]` with `.target_version: int` | The version fresh DBs should reach |
+
+Both MUST be the single authoritative source for their respective values — per [`mp-authoritative-contract-file`](../../../docs/patterns/meta-principles.md#mp-authoritative-contract-file). Do not hardcode the schema version in migrations, tests, or CI workflows; read from the authoritative constants.
+
+## Scope discipline
+
+**This test locks a single equality: `SCHEMA_VERSION_SEED == max(target_version)`.** It must NOT be extended to:
+
+- assert per-migration version gaps (`[2, 3, 5]` vs `[2, 3, 4]` — that's a different invariant, and some projects legitimately skip versions for tombstone reasons),
+- assert migration ordering (already implied by the registry's declaration order),
+- parse the schema DDL for version literals (use the constant — parsing is drift-prone),
+- assert that migrations exist for every version below the seed (covered by [`p-migration-test-coverage`](../p-migration-test-coverage/) and [`p-schema-migration-parity`](../p-schema-migration-parity/)).
+
+Widening the lock to "every number makes sense everywhere" is classic churn bait: the next time a migration is tombstoned, skipped, or renamed, the gate fires for an unrelated reason, consumers bypass it, and the genuine seed-lag defect stops being protected. One number, one check, one remediation path.
+
+(See [`mp-churn-bait-discipline`](../../../docs/patterns/meta-principles.md#mp-churn-bait-discipline).)
+
+## Stack coverage
+
+- **Python (runnable reference):** [`python/`](./python/).
+- **TypeScript (concept-only):** [`typescript/`](./typescript/).
+
+## Adversarial tests included
+
+1. `test_detects_seed_lag` (fabricated-regression) — patches the registry to include a migration targeting one version above the current seed; asserts the gate fires and names both values.
+2. `test_detects_seed_overshoot` (fabricated-regression) — patches the seed one above `max(target_version)`; asserts the gate fires and names both values.
+
+## Design principles this template obeys
+
+This pattern follows: `mp-adversarial-proof-required`, `mp-authoritative-contract-file`, `mp-churn-bait-discipline` — see [Meta-Principles](../../../docs/patterns/meta-principles.md) for context.

--- a/templates/patterns/p-schema-version-monotonic/python/__init__.py
+++ b/templates/patterns/p-schema-version-monotonic/python/__init__.py
@@ -1,0 +1,1 @@
+"""Runnable reference for the p-schema-version-monotonic pattern."""

--- a/templates/patterns/p-schema-version-monotonic/python/reference_migrations.py
+++ b/templates/patterns/p-schema-version-monotonic/python/reference_migrations.py
@@ -1,0 +1,44 @@
+"""Ordered migration registry."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+
+@dataclass(frozen=True)
+class Migration:
+    target_version: int
+    apply: Callable[[sqlite3.Connection], None]
+
+
+def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS sessions (
+            id INTEGER PRIMARY KEY,
+            user_id INTEGER NOT NULL REFERENCES users(id),
+            expires_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+def _migrate_v2_to_v3(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS audit_log (
+            id INTEGER PRIMARY KEY,
+            actor_id INTEGER NOT NULL,
+            action TEXT NOT NULL,
+            occurred_at TEXT NOT NULL
+        );
+        """
+    )
+
+
+MIGRATIONS: Tuple[Migration, ...] = (
+    Migration(target_version=2, apply=_migrate_v1_to_v2),
+    Migration(target_version=3, apply=_migrate_v2_to_v3),
+)

--- a/templates/patterns/p-schema-version-monotonic/python/reference_schema.py
+++ b/templates/patterns/p-schema-version-monotonic/python/reference_schema.py
@@ -1,0 +1,32 @@
+"""Canonical schema source carrying the version seed."""
+
+from __future__ import annotations
+
+SCHEMA_VERSION_SEED = 3
+"""The schema version fresh DBs boot at.
+
+MUST equal ``max(target_version)`` across the registered migrations —
+otherwise fresh DBs will not execute the latest migration and will diverge
+from migrated DBs. Enforced by the gate in this template.
+"""
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY,
+    email TEXT NOT NULL UNIQUE,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL REFERENCES users(id),
+    expires_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS audit_log (
+    id INTEGER PRIMARY KEY,
+    actor_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    occurred_at TEXT NOT NULL
+);
+"""

--- a/templates/patterns/p-schema-version-monotonic/python/test_schema_version_monotonic.py
+++ b/templates/patterns/p-schema-version-monotonic/python/test_schema_version_monotonic.py
@@ -1,0 +1,144 @@
+"""Schema version seed equals max(migration target_version).
+
+Defect class prevented
+----------------------
+Fresh DBs boot at ``SCHEMA_VERSION_SEED`` and then the migration runner
+advances their ``user_version`` only for migrations whose
+``target_version`` exceeds the current version. If the seed lags the
+latest migration, fresh DBs never execute the missing step — they're
+stuck at an earlier schema than legacy DBs that actually went through
+the chain.
+
+This test asserts a single equality: ``SCHEMA_VERSION_SEED ==
+max(m.target_version for m in MIGRATIONS)``.
+
+Scope discipline
+----------------
+This test locks a **single equality**. It must NOT be extended to assert
+per-migration version gaps, migration ordering, DDL-embedded version
+literals, or migration existence per version below the seed.
+
+Widening to "every number makes sense everywhere" is classic churn bait:
+the next tombstone / skip / rename fires the gate for an unrelated
+reason, consumers bypass it, and the genuine seed-lag defect stops being
+protected.
+
+(See ``mp-churn-bait-discipline``.)
+
+Adaptation
+----------
+Required hooks:
+
+- ``SCHEMA_VERSION_SEED: int`` — the version fresh DBs boot at
+- ``MIGRATIONS: Sequence[Migration]`` with ``.target_version: int``
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from . import reference_schema
+from .reference_migrations import MIGRATIONS, Migration
+
+
+def _max_target_version(migrations: Tuple[Migration, ...]) -> int:
+    if not migrations:
+        return 0
+    return max(m.target_version for m in migrations)
+
+
+def _check_seed_matches_chain(
+    seed: int, migrations: Tuple[Migration, ...]
+) -> Tuple[bool, str]:
+    """Return ``(ok, message)``. Single source of truth for the wording
+    so happy-path and red-path tests cannot drift."""
+    max_target = _max_target_version(migrations)
+    if seed == max_target:
+        return True, ""
+
+    direction = "lags" if seed < max_target else "overshoots"
+    message = (
+        f"SCHEMA_VERSION_SEED ({seed}) {direction} max(target_version) "
+        f"({max_target}). Fresh DBs boot at v{seed}; the migration registry "
+        f"advances legacy DBs to v{max_target}. "
+        f"Remediation: {'bump the seed to match the latest migration' if direction == 'lags' else 'add the missing migration(s) to cover the seed'}, "
+        f"so fresh and migrated DBs converge."
+    )
+    return False, message
+
+
+class TestSchemaVersionMonotonic:
+    """Happy path: seed equals max(target_version) in the real registry."""
+
+    def test_seed_matches_max_target_version(self) -> None:
+        ok, message = _check_seed_matches_chain(
+            reference_schema.SCHEMA_VERSION_SEED, MIGRATIONS
+        )
+        assert ok, message
+
+
+class TestSchemaVersionMonotonicRedPath:
+    """Adversarial tests — prove the gate fires in both drift directions."""
+
+    def test_detects_seed_lag(self) -> None:
+        """Fabricated-regression: append a migration one above the current
+        seed without bumping the seed. Gate must fire and name both values.
+        """
+        seed = reference_schema.SCHEMA_VERSION_SEED
+        forward_migration = Migration(
+            target_version=seed + 1, apply=lambda conn: None
+        )
+        drifted_registry = MIGRATIONS + (forward_migration,)
+
+        ok, message = _check_seed_matches_chain(seed, drifted_registry)
+
+        assert not ok, (
+            f"gate failed to detect seed lag — expected failure with "
+            f"seed={seed}, max={seed + 1}"
+        )
+        assert f"({seed})" in message, (
+            f"gate message must name the seed value, got: {message!r}"
+        )
+        assert f"({seed + 1})" in message, (
+            f"gate message must name the max target_version, got: {message!r}"
+        )
+        assert "lags" in message, (
+            f"gate message must identify the drift direction, got: {message!r}"
+        )
+
+    def test_detects_seed_overshoot(self) -> None:
+        """Fabricated-regression: bump the seed one above the registry's
+        max without adding a migration. Gate must fire and name both values.
+        """
+        seed = reference_schema.SCHEMA_VERSION_SEED
+        drifted_seed = seed + 5  # arbitrary overshoot
+
+        ok, message = _check_seed_matches_chain(drifted_seed, MIGRATIONS)
+
+        assert not ok, (
+            f"gate failed to detect seed overshoot — seed={drifted_seed}, "
+            f"max={seed}"
+        )
+        assert f"({drifted_seed})" in message, (
+            f"gate message must name the drifted seed, got: {message!r}"
+        )
+        assert f"({seed})" in message, (
+            f"gate message must name the max target_version, got: {message!r}"
+        )
+        assert "overshoots" in message, (
+            f"gate message must identify the drift direction, got: {message!r}"
+        )
+
+    def test_empty_registry_with_nonzero_seed_detects_mismatch(self) -> None:
+        """Removed-correctness: an empty registry reduces max() to 0, so
+        any non-zero seed fires. Confirms the max() computation is the
+        load-bearing arm — removing it (by emptying the registry) shifts
+        the comparison's "allowed" value to zero and exposes drift.
+        """
+        ok, message = _check_seed_matches_chain(
+            reference_schema.SCHEMA_VERSION_SEED, ()
+        )
+        assert not ok, "seed != 0 against empty registry should fire"
+        assert "(0)" in message, (
+            f"gate message must name max=0 for empty registry, got: {message!r}"
+        )

--- a/templates/patterns/p-schema-version-monotonic/typescript/README.md
+++ b/templates/patterns/p-schema-version-monotonic/typescript/README.md
@@ -1,0 +1,44 @@
+# `p-schema-version-monotonic` — TypeScript adaptation
+
+Concept-only. The check itself is trivial — one integer comparison — but where `SCHEMA_VERSION_SEED` lives and how your registry exposes `target_version` varies by ecosystem.
+
+## Apply the same one-line check
+
+```ts
+import { SCHEMA_VERSION_SEED } from "./schema";
+import { MIGRATIONS } from "./migrations";
+
+const maxTarget =
+  MIGRATIONS.length === 0
+    ? 0
+    : Math.max(...MIGRATIONS.map((m) => m.targetVersion));
+
+if (SCHEMA_VERSION_SEED !== maxTarget) {
+  throw new Error(
+    `SCHEMA_VERSION_SEED (${SCHEMA_VERSION_SEED}) != ` +
+      `max(targetVersion) (${maxTarget}). ` +
+      `Fresh DBs boot at v${SCHEMA_VERSION_SEED}; the registry advances ` +
+      `legacy DBs to v${maxTarget}. Bump the seed or add the missing migration.`,
+  );
+}
+```
+
+## Ecosystem pointers
+
+### Drizzle ORM
+
+`drizzle-kit` journals migrations with numeric indices in `drizzle/meta/_journal.json`. Read the journal's highest `idx` and compare to a `SCHEMA_VERSION_SEED` constant you maintain in your schema module — drizzle doesn't expose the seed natively, so it's a small addition.
+
+### Prisma
+
+Prisma's `prisma/migrations/` directory is timestamped, not numeric. The "version seed" concept doesn't map directly — use `prisma migrate status` to check the applied set matches the registered set, then adapt this pattern to Prisma's conventions. The churn-bait-discipline guidance still applies: lock one clear invariant, not "every timestamp makes sense."
+
+### Knex / node-pg-migrate
+
+Expose `LATEST_MIGRATION_VERSION` as a generated constant from your migrations directory (small Node script that scans filenames and picks the max index). Compare to the seed in your schema file.
+
+## Scope discipline applies identically
+
+One number, one check, one remediation path. Do not extend to per-migration gap checks or ordering asserts — those are different invariants and belong in separate tests with their own names.
+
+See the [Python reference](../python/) for the canonical shape.


### PR DESCRIPTION
## Summary

- **P1** extends `config/standards.json` with required `maturity` + optional `conditions` fields, tier-grouped `verify` output, conditional-item N/A rendering, 49 new catalog items (38 Core + 34 Recommended + 21 Optional total), and `docs/patterns/meta-principles.md` capturing the 8 cross-cutting design rules.
- **P2.1** ships the persistence template pack: 5 runnable Python references under `templates/patterns/p-*/` with adversarial tests, concept-only TypeScript READMEs, and a footer-presence CI gate (`scripts/verify-pattern-footers.ts`) that validates every pattern README's meta-principles footer + scope-discipline anchor.
- All 5 persistence items bumped atomically from `maturity: documented` → `template-available`; all 4 `instructions.*.md` + 15 per-stack/CI JSONs regenerated so consumer-facing surfaces reflect the new maturity.

## What changed

- Schema: `maturity` required (`documented` / `template-planned` / `template-available`); `conditions` optional string array (`has-database`, `has-cli`); hard schema reject on missing `maturity`.
- `VerifyResult`: `by_tier` grouping; `not_applicable` array for condition-skipped items; Core failures surface first.
- Templates:
  - `p-schema-migration-parity` — canonical schema ⊆ fundamental ∪ migration-created tables
  - `p-migration-ddl-parity` — PRAGMA-level structural equivalence (NOT raw DDL text)
  - `p-required-tables-runtime-check` — two-phase validation at DB connect (paired w/ parity test)
  - `p-schema-version-monotonic` — seed == max(target_version)
  - `p-migration-test-coverage` — registry-as-manifest + per-migration blank/prior tests
- Footer gate parses the authoritative `mp-*` set from `docs/patterns/meta-principles.md`; new principles auto-register.
- One deviation from the original P2.1 proposal: `p-migration-ddl-parity` cites `mp-churn-bait-discipline` + carries a Scope discipline anchor (raw-DDL-text extension is a concrete churn-bait risk).

## Test plan

- [ ] `npm test` passes — 102 vitest tests including 15 adversarial cases for the footer gate
- [ ] `npm run validate:schema` passes — schema validation, unique IDs, stack refs, maturity coverage
- [ ] `npm run ci` passes end-to-end
- [ ] `pytest templates/patterns/*/python/` passes — 18 Python tests across the 5 templates (happy + adversarial)
- [ ] Spot-check a regenerated `instructions.*.md` — the 5 persistence items render as `Maturity: template-available — template at templates/patterns/<id>/ — ready to copy-and-adapt`
- [ ] Spot-check `config/standards.json` — the 5 `p-*` items carry `"maturity": "template-available"` and `"conditions": ["has-database"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)